### PR TITLE
Detect service from url

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+
+gem 'lhc', '~> 1.2.0', path: '../lhc'

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.intra.local.ch/'
+source 'https://rubygems.org/'
 
 # Declare your gem's dependencies in lhs.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,3 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
-
-gem 'lhc', '~> 1.2.0', path: '../lhc'

--- a/docs/services.md
+++ b/docs/services.md
@@ -187,6 +187,26 @@ When including linked resources with `includes`, known/defined services and endp
 That also means that options for endpoints of linked resources are applied when requesting those in addition.
 This enables you to include protected resources (e.g. OAuth) as endpoint options for oauth authentication get applied.
 
+The (Auth Inteceptor)[https://github.com/local-ch/lhc-core-interceptors#auth-interceptor] from (lhc-core-interceptors)[https://github.com/local-ch/lhc-core-interceptors] is used to configure the following endpoints.
+```ruby
+class Favorite < LHS::Service
+
+  endpoint ':datastore/:user_id/favorites', auth: { bearer: -> { bearer_token } }
+  endpoint ':datastore/:user_id/favorites/:id', auth: { bearer: -> { bearer_token } }
+
+end
+
+class Place < LHS::Service
+
+  endpoint ':datastore/v2/places', auth: { bearer: -> { bearer_token } }
+  endpoint ':datastore/v2/places/:id', auth: { bearer: -> { bearer_token } }
+
+end
+
+Favorite.includes(:place).where(user_id: current_user.id) 
+# Will include places and applies endpoint options to authenticate the request.
+```
+
 ## Map data
 
 To influence how data is accessed/provied, you can use mapping to either map deep nested data or to manipulate data when its accessed:

--- a/docs/services.md
+++ b/docs/services.md
@@ -181,6 +181,12 @@ and you should read it to understand this feature in all its glory.
   feedbacks.first.campaign.entry.name # 'Casa Ferlin'
 ```
 
+### Known services are used to request linked resources
+
+When including linked resources with `includes`, known/defined services and endpoints are used to make those requests. 
+That also means that options for endpoints of linked resources are applied when requesting those in addition.
+This enables you to include protected resources (e.g. OAuth) as endpoint options for oauth authentication get applied.
+
 ## Map data
 
 To influence how data is accessed/provied, you can use mapping to either map deep nested data or to manipulate data when its accessed:

--- a/docs/services.md
+++ b/docs/services.md
@@ -5,6 +5,10 @@ A LHS::Service makes data available using multiple endpoints.
 
 ![Service](service.jpg)
 
+## Convention
+
+Please store all defined services in `app/services` as they are autoloaded from this directory.
+
 ## Endpoints
 
 You setup a service by configure one or multiple backend endpoints.

--- a/docs/services.md
+++ b/docs/services.md
@@ -187,7 +187,7 @@ When including linked resources with `includes`, known/defined services and endp
 That also means that options for endpoints of linked resources are applied when requesting those in addition.
 This enables you to include protected resources (e.g. OAuth) as endpoint options for oauth authentication get applied.
 
-The (Auth Inteceptor)[https://github.com/local-ch/lhc-core-interceptors#auth-interceptor] from (lhc-core-interceptors)[https://github.com/local-ch/lhc-core-interceptors] is used to configure the following endpoints.
+The [Auth Inteceptor](https://github.com/local-ch/lhc-core-interceptors#auth-interceptor) from [lhc-core-interceptors](https://github.com/local-ch/lhc-core-interceptors) is used to configure the following endpoints.
 ```ruby
 class Favorite < LHS::Service
 

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 1.9.2'
   s.required_ruby_version = '>= 1.9.2'
 
-  s.add_dependency 'lhc', '>= 0.2.0'
+  s.add_dependency 'lhc', '>= 1.2.0'
   s.add_dependency 'lhc-core-interceptors', '>= 0.1.0'
 
   s.add_development_dependency 'rspec-rails', '>= 3.0.0'

--- a/lib/lhs.rb
+++ b/lib/lhs.rb
@@ -4,3 +4,10 @@ module LHS
 end
 
 Gem.find_files('lhs/**/*.rb').each { |path| require path }
+
+# Preload all the services that are defined in app/services
+class Engine < Rails::Engine
+  initializer 'Load all services' do |app|
+    Dir.glob(app.root.join('app/services/**.rb')).each {|file| require file }
+  end
+end

--- a/lib/lhs.rb
+++ b/lib/lhs.rb
@@ -8,6 +8,6 @@ Gem.find_files('lhs/**/*.rb').each { |path| require path }
 # Preload all the services that are defined in app/services
 class Engine < Rails::Engine
   initializer 'Load all services' do |app|
-    Dir.glob(app.root.join('app/services/**.rb')).each {|file| require file }
+    Dir.glob(app.root.join('app/services/**/*.rb')).each {|file| require file }
   end
 end

--- a/lib/lhs/concerns/service/endpoints.rb
+++ b/lib/lhs/concerns/service/endpoints.rb
@@ -10,6 +10,7 @@ class LHS::Service
     extend ActiveSupport::Concern
 
     attr_accessor :endpoints
+    mattr_accessor :all
 
     module ClassMethods
 
@@ -18,6 +19,15 @@ class LHS::Service
         endpoint = LHC::Endpoint.new(url, options)
         instance.sanity_check(endpoint)
         instance.endpoints.push(endpoint)
+        LHS::Service::Endpoints.all ||= {}
+        LHS::Service::Endpoints.all[url] = instance
+      end
+
+      def for_url(url)
+        template, service = LHS::Service::Endpoints.all.detect do |template, _service|
+          LHC::Endpoint.match?(url, template)
+        end
+        service
       end
     end
 

--- a/lib/lhs/concerns/service/request.rb
+++ b/lib/lhs/concerns/service/request.rb
@@ -25,7 +25,7 @@ class LHS::Service
     end
 
     def convert_option_to_endpoints(option)
-      new_options = {}
+      new_options = option.dup
       url = option[:url]
       return unless endpoint = LHS::Endpoint.for_url(url)
       template = endpoint.url
@@ -60,7 +60,7 @@ class LHS::Service
         url_option_for(data, key)
       end
       service = service_for_options(options) || self
-      options = convert_options_to_endpoints(options) if service
+      options = convert_options_to_endpoints(options) if service_for_options(options)
       addition = if (further_keys = includes.fetch(key, nil) if includes.is_a? Hash)
         service.class.includes(further_keys).instance.request(options)
       else
@@ -111,7 +111,7 @@ class LHS::Service
           next unless service = LHS::Service.for_url(option[:url])
           services.push(service)
         end
-        fail 'Found more then one service that could be used to do the request' if services.uniq.count > 1
+        fail 'Found more than one service that could be used to do the request' if services.uniq.count > 1
         services.uniq.first
       else # Hash
         LHS::Service.for_url(options[:url])

--- a/lib/lhs/concerns/service/request.rb
+++ b/lib/lhs/concerns/service/request.rb
@@ -17,8 +17,8 @@ class LHS::Service
 
     # Convert URLs in options to endpoint templates
     def convert_options_to_endpoints(options)
-      if options.is_a? Array
-        options.map{ |option| convert_option_to_endpoints(option) }
+      if options.respond_to?(:map)
+        options.map { |option| convert_option_to_endpoints(option) }
       else
         convert_option_to_endpoints(options)
       end

--- a/lib/lhs/concerns/service/request.rb
+++ b/lib/lhs/concerns/service/request.rb
@@ -59,7 +59,6 @@ class LHS::Service
       else
         url_option_for(data, key)
       end
-      binding.pry
       service = service_for_options(options) || self
       options = convert_options_to_endpoints(options) if service
       addition = if (further_keys = includes.fetch(key, nil) if includes.is_a? Hash)

--- a/lib/lhs/concerns/service/request.rb
+++ b/lib/lhs/concerns/service/request.rb
@@ -15,60 +15,23 @@ class LHS::Service
 
     private
 
-    def multiple_requests(options)
-      options.map { |options| process_options(options) }
-      responses = LHC.request(options)
-      data = responses.map{ |response| LHS::Data.new(response.body, nil, self.class, response.request) }
-      data = LHS::Data.new(data, nil, self.class)
-      handle_includes(data) if includes
-      data
-    end
-
-    def single_request(options)
-      response = LHC.request(process_options(options))
-      data = LHS::Data.new(response.body, nil, self.class, response.request)
-      handle_includes(data) if includes
-      data
-    end
-
-    # Merge explicit params and take configured endpoints options as base
-    def process_options(options)
-      endpoint = find_endpoint(options[:params])
-      options = (endpoint.options || {}).merge(options)
-      options[:url] = compute_url!(options[:params]) unless options.key?(:url)
-      merge_explicit_params!(options[:params])
-      options.delete(:params) if options[:params] && options[:params].empty?
-      options
-    end
-
-    # Merge explicit params nested in 'params' namespace with original hash.
-    def merge_explicit_params!(params)
-      return true unless params
-      explicit_params = params[:params]
-      params.delete(:params)
-      params.merge!(explicit_params) if explicit_params
-    end
-
-    def handle_includes(data)
-      if includes.is_a? Hash
-        includes.keys.each { |key| handle_include(data, key) }
+    # Convert URLs in options to endpoint templates
+    def convert_options_to_endpoints(options)
+      if options.is_a? Array
+        options.map{ |option| convert_option_to_endpoints(option) }
       else
-        handle_include(data, includes)
+        convert_option_to_endpoints(options)
       end
     end
 
-    def handle_include(data, key)
-      options = if data._proxy.is_a? LHS::Collection
-        include_multiple(data, key)
-      else
-        include_single(data, key)
-      end
-      addition = if (further_keys = includes.fetch(key, nil) if includes.is_a? Hash)
-        self.class.includes(further_keys).instance.request(options)
-      else
-        self.class.includes(nil).instance.request(options)
-      end
-      extend(data, addition, key)
+    def convert_option_to_endpoints(option)
+      new_options = {}
+      url = option[:url]
+      return unless endpoint = LHS::Endpoint.for_url(url)
+      template = endpoint.url
+      new_options = new_options.merge(params: LHC::Endpoint.values_as_params(template, url))
+      new_options[:url] = template
+      new_options
     end
 
     def extend(data, addition, key)
@@ -82,13 +45,88 @@ class LHS::Service
       end
     end
 
-    def include_multiple(data, key)
-      data.map do |item|
-        include_single(item, key)
+    def handle_includes(data)
+      if includes.is_a? Hash
+        includes.keys.each { |key| handle_include(data, key) }
+      else
+        handle_include(data, includes)
       end
     end
 
-    def include_single(item, key)
+    def handle_include(data, key)
+      options = if data._proxy.is_a? LHS::Collection
+        options_for_multiple(data, key)
+      else
+        url_option_for(data, key)
+      end
+      binding.pry
+      service = service_for_options(options) || self
+      options = convert_options_to_endpoints(options) if service
+      addition = if (further_keys = includes.fetch(key, nil) if includes.is_a? Hash)
+        service.class.includes(further_keys).instance.request(options)
+      else
+        service.class.includes(nil).instance.request(options)
+      end
+      extend(data, addition, key)
+    end
+
+    # Merge explicit params nested in 'params' namespace with original hash.
+    def merge_explicit_params!(params)
+      return true unless params
+      explicit_params = params[:params]
+      params.delete(:params)
+      params.merge!(explicit_params) if explicit_params
+    end
+
+    def multiple_requests(options)
+      options = options.map { |options| process_options(options) }
+      responses = LHC.request(options)
+      data = responses.map{ |response| LHS::Data.new(response.body, nil, self.class, response.request) }
+      data = LHS::Data.new(data, nil, self.class)
+      handle_includes(data) if includes
+      data
+    end
+
+    def options_for_multiple(data, key)
+      data.map do |item|
+        url_option_for(item, key)
+      end
+    end
+
+    # Merge explicit params and take configured endpoints options as base
+    def process_options(options)
+      options ||= {}
+      options = options.dup
+      endpoint = find_endpoint(options[:params])
+      options = (endpoint.options || {}).merge(options)
+      options[:url] = compute_url!(options[:params]) unless options.key?(:url)
+      merge_explicit_params!(options[:params])
+      options.delete(:params) if options[:params] && options[:params].empty?
+      options
+    end
+
+    def service_for_options(options)
+      services = []
+      if options.is_a?(Array)
+        options.each do |option|
+          next unless service = LHS::Service.for_url(option[:url])
+          services.push(service)
+        end
+        fail 'Found more then one service that could be used to do the request' if services.uniq.count > 1
+        services.uniq.first
+      else # Hash
+        LHS::Service.for_url(options[:url])
+      end
+    end
+
+    def single_request(options)
+      response = LHC.request(process_options(options))
+      data = LHS::Data.new(response.body, nil, self.class, response.request)
+      handle_includes(data) if includes
+      data
+    end
+
+    def url_option_for(item, key)
       link = item[key]
       { url: link.href }
     end

--- a/lib/lhs/endpoint.rb
+++ b/lib/lhs/endpoint.rb
@@ -1,0 +1,11 @@
+# An endpoint is used as source to fetch objects
+class LHS::Endpoint
+  
+  def self.for_url(url)
+    template, service = LHS::Service::Endpoints.all.detect do |template, _service|
+      LHC::Endpoint.match?(url, template)
+    end
+    service.endpoints.detect { |endpoint| endpoint.url == template } if service
+  end
+end
+

--- a/spec/endpoint/for_url_spec.rb
+++ b/spec/endpoint/for_url_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe LHS::Endpoint do
+
+  context 'for url' do
+
+    before(:each) do
+      class SomeService < LHS::Service
+        endpoint ':datastore/entries/:entry_id/content-ads/:campaign_id/feedbacks'
+        endpoint ':datastore/:campaign_id/feedbacks'
+        endpoint ':datastore/feedbacks'
+      end
+    end
+
+    it 'provides the endpoint for a given url' do
+      expect(
+        LHS::Endpoint.for_url('http://datastore.local.ch/v2/entries/123/content-ads/456/feedbacks').url
+      ).to eq ':datastore/entries/:entry_id/content-ads/:campaign_id/feedbacks'
+      expect(
+        LHS::Endpoint.for_url('http://datastore.local.ch/123/feedbacks').url
+      ).to eq ':datastore/:campaign_id/feedbacks'
+      expect(
+        LHS::Endpoint.for_url('http://datastore.local.ch/feedbacks').url
+      ).to eq ':datastore/feedbacks'
+    end
+  end
+end

--- a/spec/service/endpoints_spec.rb
+++ b/spec/service/endpoints_spec.rb
@@ -15,6 +15,12 @@ describe LHS::Service do
       end
     end
 
+    it 'stores all the endpoints by url' do
+      expect(LHS::Service::Endpoints.all[':datastore/entries/:entry_id/content-ads/:campaign_id/feedbacks']).to be 
+      expect(LHS::Service::Endpoints.all[':datastore/:campaign_id/feedbacks']).to be
+      expect(LHS::Service::Endpoints.all[':datastore/feedbacks']).to be
+    end
+
     it 'stores the endpoints of the service' do
       expect(SomeService.instance.endpoints.count).to eq 3
       expect(SomeService.instance.endpoints[0].url).to eq ':datastore/entries/:entry_id/content-ads/:campaign_id/feedbacks'

--- a/spec/service/includes_spec.rb
+++ b/spec/service/includes_spec.rb
@@ -5,40 +5,40 @@ describe LHS::Service do
   let(:datastore) { 'http://datastore-stg.lb-service.sunrise.intra.local.ch/v2' }
   before(:each) { LHC.config.placeholder('datastore', datastore) }
 
+  let(:stub_campaign_request) do
+    stub_request(:get, "#{datastore}/content-ads/51dfc5690cf271c375c5a12d")
+      .to_return(body: {
+        'href' => "#{datastore}/content-ads/51dfc5690cf271c375c5a12d",
+        'entry' => { 'href' => "#{datastore}/local-entries/lakj35asdflkj1203va" }
+      }.to_json)
+  end
+
+  let(:stub_entry_request) do
+    stub_request(:get, "#{datastore}/local-entries/lakj35asdflkj1203va")
+      .to_return(body: { 'name' => 'Casa Ferlin' }.to_json)
+  end
+
   context 'includes' do
 
     before(:each) do
       class Feedback < LHS::Service
         endpoint ':datastore/feedbacks'
       end
-
-      stub_request(:get, "#{datastore}/content-ads/51dfc5690cf271c375c5a12d")
-      .to_return(status: 200, body: {
-         "href" => "#{datastore}/content-ads/51dfc5690cf271c375c5a12d",
-         "entry" => {
-           "href" => "#{datastore}/local-entries/lakj35asdflkj1203va"
-         }
-      }.to_json)
-
-      stub_request(:get, "#{datastore}/local-entries/lakj35asdflkj1203va")
-      .to_return(status: 200, body: {
-         "name" => 'Casa Ferlin'
-      }.to_json)
+      stub_campaign_request
+      stub_entry_request
     end
 
     it 'includes linked resources while fetching multiple resources from one service' do
 
       stub_request(:get, "#{datastore}/feedbacks?has_reviews=true")
-      .to_return(status: 200, body: {
-          items:[
+        .to_return(status: 200, body: {
+          items: [
             {
-              "href" => "#{datastore}/feedbacks/-Sc4_pYNpqfsudzhtivfkA",
-              "campaign" => {
-                "href" => "#{datastore}/content-ads/51dfc5690cf271c375c5a12d"
-              }
+              'href' => "#{datastore}/feedbacks/-Sc4_pYNpqfsudzhtivfkA",
+              'campaign' => { 'href' => "#{datastore}/content-ads/51dfc5690cf271c375c5a12d" }
             }
           ]
-      }.to_json)
+        }.to_json)
 
       feedbacks = Feedback.includes(campaign: :entry).where(has_reviews: true)
       expect(feedbacks.first.campaign.entry.name).to eq 'Casa Ferlin'
@@ -47,15 +47,49 @@ describe LHS::Service do
     it 'includes linked resources while fetching a single resource from one service' do
 
       stub_request(:get, "#{datastore}/feedbacks/123")
-      .to_return(status: 200, body: {
-        "href" => "#{datastore}/feedbacks/-Sc4_pYNpqfsudzhtivfkA",
-        "campaign" => {
-          "href" => "#{datastore}/content-ads/51dfc5690cf271c375c5a12d"
-        }
-      }.to_json)
+        .to_return(status: 200, body: {
+          'href' => "#{datastore}/feedbacks/-Sc4_pYNpqfsudzhtivfkA",
+          'campaign' => { 'href' => "#{datastore}/content-ads/51dfc5690cf271c375c5a12d" }
+        }.to_json)
 
       feedbacks = Feedback.includes(campaign: :entry).find(123)
       expect(feedbacks.campaign.entry.name).to eq 'Casa Ferlin'
+    end
+
+    context 'include objects from known services' do
+
+      let(:stub_feedback_request) do
+        stub_request(:get, "#{datastore}/feedbacks")
+          .to_return(status: 200, body: {
+              items: [
+                {
+                  'href' => "#{datastore}/feedbacks/-Sc4_pYNpqfsudzhtivfkA",
+                  'entry' => {
+                    'href' => "#{datastore}/local-entries/lakj35asdflkj1203va"
+                  }
+                }
+              ]
+          }.to_json)
+      end
+
+      before(:each) do
+        class Entry < LHS::Service
+          endpoint ':datastore/local-entries/:id'
+        end
+        class SomeInterceptor < LHC::Interceptor; end
+        LHC.config.interceptors = [SomeInterceptor]
+      end
+
+      it 'uses interceptors for included links from known services' do
+        stub_feedback_request
+        stub_entry_request
+
+        @called = 0
+        allow_any_instance_of(SomeInterceptor).to receive(:before_request) { @called += 1 }
+
+        expect(Feedback.includes(:entry).where.first.entry.name).to eq 'Casa Ferlin'
+        expect(@called).to eq 2
+      end
     end
   end
 end

--- a/spec/support/cleanup_endpoints.rb
+++ b/spec/support/cleanup_endpoints.rb
@@ -1,0 +1,6 @@
+RSpec.configure do |config|
+
+  config.before(:each) do
+    LHS::Service::Endpoints.all = {}
+  end
+end


### PR DESCRIPTION
When using `includes` to include linked objects use known services for doing the request to be able to apply endpoint configurations from their service definitions (e.g. Auth).