### PR TITLE
No implicit id parameter handling anymore

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -18,7 +18,9 @@ You can also add request options for an endpoint (see following example).
 class Feedback < LHS::Service
 
   endpoint ':datastore/v2/content-ads/:campaign_id/feedbacks'
+  endpoint ':datastore/v2/content-ads/:campaign_id/feedbacks/:id'
   endpoint ':datastore/v2/feedbacks', cache: true, cache_expires_in: 1.day
+  endpoint ':datastore/v2/feedbacks/:id', cache: true, cache_expires_in: 1.day
 
 end
 ```

--- a/lib/lhs/concerns/service/endpoints.rb
+++ b/lib/lhs/concerns/service/endpoints.rb
@@ -57,7 +57,6 @@ class LHS::Service
     def compute_url!(params)
       endpoint = find_endpoint(params)
       url = endpoint.compile(params)
-      url +=  "/#{params.delete(:id)}" if params && params[:id]
       endpoint.remove_interpolated_params!(params)
       url
     end

--- a/spec/collection/meta_data_spec.rb
+++ b/spec/collection/meta_data_spec.rb
@@ -31,9 +31,11 @@ describe LHS::Collection do
     LHC.config.placeholder('datastore', datastore)
     class Feedback < LHS::Service
       endpoint ':datastore/feedbacks'
+      endpoint ':datastore/feedbacks/:id'
     end
     class User < LHS::Service
       endpoint ':datastore/users'
+      endpoint ':datastore/users/:id'
     end
   end
 

--- a/spec/collection/without_object_items_spec.rb
+++ b/spec/collection/without_object_items_spec.rb
@@ -7,7 +7,7 @@ describe LHS::Collection do
   before(:each) do
     LHC.config.placeholder('datastore', datastore)
     class Account < LHS::Service
-      endpoint ':datastore/accounts'
+      endpoint ':datastore/accounts/:id'
     end
   end
 

--- a/spec/service/endpoint_options_spec.rb
+++ b/spec/service/endpoint_options_spec.rb
@@ -6,7 +6,7 @@ describe LHS::Service do
 
     before(:each) do
       class SomeService < LHS::Service
-        endpoint 'backend/v2/feedbacks', cache_expires_in: 1.day, retry: 2, cache: true
+        endpoint 'backend/v2/feedbacks/:id', cache_expires_in: 1.day, retry: 2, cache: true
       end
     end
 

--- a/spec/service/endpoints_spec.rb
+++ b/spec/service/endpoints_spec.rb
@@ -43,6 +43,21 @@ describe LHS::Service do
       ).to eq ':datastore/feedbacks'
     end
 
+    context 'compute url from endpoint' do
+
+      before(:each) do
+        class Feedback < LHS::Service
+          endpoint ':datastore/feedbacks'
+          endpoint ':datastore/feedbacks/:id'
+        end
+      end
+
+      it 'computes urls WITHOUT handling id separate' do
+        stub_request(:get, "#{datastore}/feedbacks/1").to_return(status: 200)
+        Feedback.find(1)
+      end
+    end
+
     context 'unsorted endpoints' do
 
       before(:each) do

--- a/spec/service/find_by_spec.rb
+++ b/spec/service/find_by_spec.rb
@@ -7,7 +7,9 @@ describe LHS::Service do
     LHC.config.placeholder(:datastore, datastore)
     class SomeService < LHS::Service
       endpoint ':datastore/content-ads/:campaign_id/feedbacks'
+      endpoint ':datastore/content-ads/:campaign_id/feedbacks/:id'
       endpoint ':datastore/feedbacks'
+      endpoint ':datastore/feedbacks/:id'
     end
   end
 

--- a/spec/service/find_spec.rb
+++ b/spec/service/find_spec.rb
@@ -8,7 +8,9 @@ describe LHS::Service do
     LHC.config.placeholder(:datastore, datastore)
     class SomeService < LHS::Service
       endpoint ':datastore/content-ads/:campaign_id/feedbacks'
+      endpoint ':datastore/content-ads/:campaign_id/feedbacks/:id'
       endpoint ':datastore/feedbacks'
+      endpoint ':datastore/feedbacks/:id'
     end
   end
 

--- a/spec/service/includes_spec.rb
+++ b/spec/service/includes_spec.rb
@@ -23,6 +23,7 @@ describe LHS::Service do
     before(:each) do
       class Feedback < LHS::Service
         endpoint ':datastore/feedbacks'
+        endpoint ':datastore/feedbacks/:id'
       end
       stub_campaign_request
       stub_entry_request

--- a/spec/service/mapping_spec.rb
+++ b/spec/service/mapping_spec.rb
@@ -10,6 +10,7 @@ describe LHS::Service do
       LHC.config.placeholder('datastore', datastore)
       class LocalEntry < LHS::Service
         endpoint ':datastore/local-entries'
+        endpoint ':datastore/local-entries/:id'
       end
     end
 


### PR DESCRIPTION
It was a bad idea to handle id as an implicit parameter.

It led to an issue where the id was passed as url parameter twice: https://github.com/local-ch/lhs/issues/33

So I decided to completely remove the implicit id handling and make it transparent.

## Major version increase