### PR TITLE
reproduce errors in specs

### DIFF
--- a/lib/lhs/concerns/record/all.rb
+++ b/lib/lhs/concerns/record/all.rb
@@ -16,7 +16,7 @@ class LHS::Record
         default_max_limit = 100
         data = request(params: params.merge(limit: default_max_limit))
         all.concat(all_items_from(data))
-        request_all_the_rest(data, all, params) if data._raw.is_a?(Hash) && data._raw[:total] && data._raw[:limit]
+        request_all_the_rest(data, all, params) if data._raw.is_a?(Hash) && data._raw[:total]
         data._record_class.new(LHS::Data.new(all, nil, self))
       end
 

--- a/lib/lhs/concerns/record/all.rb
+++ b/lib/lhs/concerns/record/all.rb
@@ -21,7 +21,7 @@ class LHS::Record
       end
 
       private
-      
+
       def all_items_from(data)
         if data._raw.is_a?(Array)
           data._raw

--- a/lib/lhs/concerns/record/all.rb
+++ b/lib/lhs/concerns/record/all.rb
@@ -15,7 +15,22 @@ class LHS::Record
         all = []
         default_max_limit = 100
         data = request(params: params.merge(limit: default_max_limit))
-        all.concat(data._raw[:items])
+        all.concat(all_items_from(data))
+        request_all_the_rest(data, all, params) if data._raw.is_a?(Hash) && data._raw[:total] && data._raw[:limit]
+        data._record_class.new(LHS::Data.new(all, nil, self))
+      end
+
+      private
+      
+      def all_items_from(data)
+        if data._raw.is_a?(Array)
+          data._raw
+        else
+          data._raw[:items]
+        end
+      end
+
+      def request_all_the_rest(data, all, params)
         total_left = data._raw[:total] - data.count
         limit = data._raw[:limit] || data.count
         if limit > 0
@@ -25,7 +40,6 @@ class LHS::Record
             all.concat request(params: params.merge(limit: limit, offset: offset))._raw[:items]
           end
         end
-        data._record_class.new(LHS::Data.new(all, nil, self))
       end
     end
   end

--- a/spec/record/all_spec.rb
+++ b/spec/record/all_spec.rb
@@ -48,5 +48,21 @@ describe LHS::Collection do
       expect(all._proxy).to be_kind_of LHS::Collection
       expect(all.count).to eq 0
     end
+
+    it 'alsow works when there is no total in the stubbing' do
+      stub_request(:get, %r{/feedbacks}).to_return(body: { items: (1..100).to_a }.to_json)
+      all = Record.all
+      expect(all).to be_kind_of Record
+      expect(all._proxy).to be_kind_of LHS::Collection
+      expect(all.count).to eq 0
+    end
+
+    it 'alsow works when there is no key "items" in the stubbing' do
+      stub_request(:get, %r{/feedbacks}).to_return(body: (1..100).to_a.to_json)
+      all = Record.all
+      expect(all).to be_kind_of Record
+      expect(all._proxy).to be_kind_of LHS::Collection
+      expect(all.count).to eq 0
+    end
   end
 end

--- a/spec/record/all_spec.rb
+++ b/spec/record/all_spec.rb
@@ -54,7 +54,7 @@ describe LHS::Collection do
       all = Record.all
       expect(all).to be_kind_of Record
       expect(all._proxy).to be_kind_of LHS::Collection
-      expect(all.count).to eq 0
+      expect(all.count).to eq 100
     end
 
     it 'alsow works when there is no key "items" in the stubbing' do
@@ -62,7 +62,7 @@ describe LHS::Collection do
       all = Record.all
       expect(all).to be_kind_of Record
       expect(all._proxy).to be_kind_of LHS::Collection
-      expect(all.count).to eq 0
+      expect(all.count).to eq 100
     end
   end
 end


### PR DESCRIPTION
# Error case
It is not possible to spec requests like this when the method `all` is used inside controller:
### controller
```ruby
def index
    @callcenters = Spamnumber.all(type: 'Verified', order_by: '-user_frequency', swiss_number: true)
end
```
### spec
```ruby
let(:callcenters) { [callcenter] }
before :each doe
      stub_request(:get, %r{/spamnumbers}).to_return(body: callcenters.to_json)
end
```
Instead requests have to be stubbed like this:
### spec
```ruby
let(:callcenters) { { items: [callcenter], total: 1 } }
before :each doe
      stub_request(:get, %r{/spamnumbers}).to_return(body: callcenters.to_json)
end
```
This error case is reproduced in the red specs from following spec-file:
```bash
rspec spec/record/all_spec.rb
```