### PR TITLE
Fix includes

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'geminabox'
   s.add_development_dependency 'pry'
+  s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'ciderizer'
   s.add_development_dependency 'capybara'
 end

--- a/lib/lhs/concerns/record/includes.rb
+++ b/lib/lhs/concerns/record/includes.rb
@@ -16,7 +16,7 @@ class LHS::Record
 
       def includes(*args)
         name = "#{self}#{args.object_id}"
-        constant = Object.const_set(name.demodulize, self)
+        constant = Object.const_set(name.demodulize, self.dup) # rubocop:disable Style/RedundantSelf
         class_clone = constant
         class_clone.endpoints = endpoints
         class_clone.mapping = mapping

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -53,6 +53,10 @@ describe LHS::Record do
       expect(favorite.local_entry.company_name).to eq 'local.ch'
     end
 
+    it 'duplicates a class' do
+      expect(Favorite.object_id).not_to eq(Favorite.includes(:local_entry).object_id)
+    end
+
     it 'includes a list of resources' do
       favorite = Favorite.includes(:local_entry, :user).find(1)
       expect(favorite.local_entry).to be_kind_of LocalEntry


### PR DESCRIPTION
`includes` was not duplicating a class so it was always hanging around.
The issue become visible when we changed the `create` behaviour.
It is fixed now 