### PR TITLE
+ where chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ This uses the `:datastore/v2/feedbacks` endpoint, cause `:campaign_id` was not p
 
 Uses the `:datastore/v2/content-ads/:campaign_id/feedbacks` endpoint.
 
+## Scopes / WhereChains
+
+LHS supports WhereChains. That allows you to chain multiple where-queries and helps you organizing query parameters that are used often in scopes (methods):
+
+```ruby
+class Record < LHS::Record
+  endpoint 'records/'
+  endpoint 'records/:id'
+
+  def self.blue
+    where(color: 'blue')
+  end
+end
+
+records = Record.blue.where(available: true)
+...
+records.where(sort: 'DESC').each do |record|
+  ...
+end
+```
+The example would fetch the following in the end: `{color: blue, available: true, sort: 'DESC'}`.
+
 ## Find single records
 
 `find` finds a unique record by uniqe identifier (usualy id).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The example would fetch records with the following parameters: `{color: blue, av
 
 ## Where values hash
 
-Returns a hash of where conditions (active-record-like).
+Returns a hash of where conditions.
 Common to use in tests, as where queries are not performing any HTTP-requests when no data is accessed.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ In order to make common where statements reusable you can organise them in scope
 class Record < LHS::Record
   endpoint 'records/'
   endpoint 'records/:id'
-  scope :blue, -> {color: 'blue'}
-  scope :available ->(state) {available: state}
+  scope :blue, -> { where(color: 'blue') }
+  scope :available ->(state) { where(available: state) }
 end
 
 records = Record.blue.available(true)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ records = Record.where(color: 'blue').where(available: true).where(color: 'red')
 
 expect(
   records
-).to have_requested "something" # will fail as no http request is made (no data requested)
+).to have_requested(:get, %r{records/})
+  .with(query: hash_including(color: 'blue', available: true))
+# will fail as no http request is made (no data requested)
 
 expect(
   records.where_values_hash

--- a/README.md
+++ b/README.md
@@ -66,27 +66,40 @@ This uses the `:datastore/v2/feedbacks` endpoint, cause `:campaign_id` was not p
 
 Uses the `:datastore/v2/content-ads/:campaign_id/feedbacks` endpoint.
 
-## Scopes / WhereChains
+## Chaining where statements
 
-LHS supports WhereChains. That allows you to chain multiple where-queries and helps you organizing query parameters that are used often in scopes (methods):
+LHS supports chaining where statements. 
+That allows you to chain multiple where-queries:
 
 ```ruby
 class Record < LHS::Record
   endpoint 'records/'
   endpoint 'records/:id'
-
-  def self.blue
-    where(color: 'blue')
-  end
 end
 
-records = Record.blue.where(available: true)
+records = Record.where(color: 'blue')
 ...
-records.where(visible: true).each do |record|
+records.where(available: true).each do |record|
   ...
 end
 ```
-The example would fetch the following in the end: `{color: blue, available: true, visible: true}`.
+The example would fetch records with the following parameters: `{color: blue, available: true}`.
+
+## Scopes: Reuse where statements
+
+In order to make common where statements reusable you can organise them in scopes:
+
+```ruby
+class Record < LHS::Record
+  endpoint 'records/'
+  endpoint 'records/:id'
+  scope :blue, -> {color: 'blue'}
+  scope :available ->(state) {available: state}
+end
+
+records = Record.blue.available(true)
+The example would fetch records with the following parameters: `{color: blue, visible: true}`.
+```
 
 ## Find single records
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ end
 
 records = Record.blue.where(available: true)
 ...
-records.where(sort: 'DESC').each do |record|
+records.where(visible: true).each do |record|
   ...
 end
 ```
-The example would fetch the following in the end: `{color: blue, available: true, sort: 'DESC'}`.
+The example would fetch the following in the end: `{color: blue, available: true, visible: true}`.
 
 ## Find single records
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ class Record < LHS::Record
   endpoint 'records/'
   endpoint 'records/:id'
   scope :blue, -> { where(color: 'blue') }
-  scope :available ->(state) { where(available: state) }
+  scope :available, ->(state) { where(available: state) }
 end
 
 records = Record.blue.available(true)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ end
 ```
 The example would fetch records with the following parameters: `{color: blue, available: true}`.
 
+## Where values hash
+
+Returns a hash of where conditions (active-record-like).
+Common to use in tests, as where queries are not performing any HTTP-requests when no data is accessed.
+
+```
+records = Record.where(color: 'blue').where(available: true).where(color: 'red')
+
+expect(
+  records
+).to have_requested "something" # will fail as no http request is made (no data requested)
+
+expect(
+  records.where_values_hash
+).to eq {color: 'red', available: true}
+```
+
 ## Scopes: Reuse where statements
 
 In order to make common where statements reusable you can organise them in scopes:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The example would fetch records with the following parameters: `{color: blue, av
 Returns a hash of where conditions (active-record-like).
 Common to use in tests, as where queries are not performing any HTTP-requests when no data is accessed.
 
-```
+```ruby
 records = Record.where(color: 'blue').where(available: true).where(color: 'red')
 
 expect(

--- a/lib/lhs/concerns/record/scope.rb
+++ b/lib/lhs/concerns/record/scope.rb
@@ -1,0 +1,23 @@
+require 'active_support'
+
+class LHS::Record
+
+  # Scopes allow you to reuse common where queries
+  module Scope
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def scope(name, block)
+        scopes[name] = block
+        define_singleton_method(name) do |*args|
+          block.call(*args)
+        end
+      end
+
+      def scopes
+        @scopes ||= {}
+        @scopes
+      end
+    end
+  end
+end

--- a/lib/lhs/concerns/record/where.rb
+++ b/lib/lhs/concerns/record/where.rb
@@ -21,7 +21,7 @@ class LHS::Record
         self
       end
 
-      # Returns a hash of where conditions (active-record-like).
+      # Returns a hash of where conditions
       def where_values_hash
         merged_parameters
       end

--- a/lib/lhs/concerns/record/where.rb
+++ b/lib/lhs/concerns/record/where.rb
@@ -30,8 +30,7 @@ class LHS::Record
       end
 
       def resolve
-        return @resolved if @resolved
-        @resolved = @record.new(
+        @resolved ||= @record.new(
           @record.request(params: merged_parameters)
         )
       end

--- a/lib/lhs/concerns/record/where.rb
+++ b/lib/lhs/concerns/record/where.rb
@@ -21,6 +21,11 @@ class LHS::Record
         self
       end
 
+      # Returns a hash of where conditions (active-record-like).
+      def where_values_hash
+        merged_parameters
+      end
+
       protected
 
       def method_missing(name, *args, &block)

--- a/lib/lhs/concerns/record/where.rb
+++ b/lib/lhs/concerns/record/where.rb
@@ -5,11 +5,51 @@ class LHS::Record
   module Where
     extend ActiveSupport::Concern
 
+    class WhereChain
+
+      delegate *Object.instance_methods, to: :resolve
+
+      def initialize(record, parameters)
+        @record = record
+        @chain = [parameters].compact
+      end
+
+      def where(parameters)
+        @chain += [parameters].compact
+        self
+      end
+
+      protected
+
+      def method_missing(name, *args, &block)
+        resolve.send(name, *args, &block)
+      end
+
+      def respond_to_missing?(name, include_all = false)
+        resolve.respond_to?(name, include_all)
+      end
+
+      def resolve
+        return @resolved if @resolved
+        @resolved = @record.new(
+          @record.request(params: merged_parameters)
+        )
+      end
+
+      private
+
+      def merged_parameters
+        merged_parameters = {}
+        @chain.each do |parameter|
+          merged_parameters.deep_merge!(parameter)
+        end
+        merged_parameters
+      end
+    end
+
     module ClassMethods
-      # Used to query data from the service.
-      def where(params = {})
-        data = request(params: params)
-        data._record.new(data)
+      def where(parameters = nil)
+        WhereChain.new(self, parameters)
       end
     end
   end

--- a/lib/lhs/concerns/record/where.rb
+++ b/lib/lhs/concerns/record/where.rb
@@ -7,7 +7,7 @@ class LHS::Record
 
     class WhereChain
 
-      delegate *Object.instance_methods, to: :resolve
+      delegate(*Object.instance_methods, to: :resolve)
 
       def initialize(record, parameters)
         @record = record

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -12,6 +12,7 @@ class LHS::Record
   include Mapping
   include Model
   include Includes
+  include Scope
   include Request
   include Where
   include Pagination

--- a/spec/record/scope_chains_spec.rb
+++ b/spec/record/scope_chains_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  let(:datastore) do
+    'http://datastore/v2'
+  end
+
+  let(:response) do
+    { body: [{ name: 'Steve' }] }
+  end
+
+  before(:each) do
+    LHC.config.placeholder('datastore', datastore)
+    class Record < LHS::Record
+      endpoint ':datastore/records/'
+      scope :blue, -> { where(color: 'blue') }
+      scope :available, -> { where(availalbe: 'true') }
+      scope :limited_to, ->(limit) { where(limit: limit) }
+    end
+  end
+
+  context 'scope chains' do
+    it 'allows chaining multiple scopes' do
+      stub_request(:get, "http://datastore/v2/records/?availalbe=true&color=blue&limit=20").to_return(response)
+      expect(
+        Record.blue.available.limited_to(20).first.name
+      ).to eq 'Steve'
+    end
+
+    it 'allows to chain multiple scopes when first one has arguments' do
+      stub_request(:get, "http://datastore/v2/records/?availalbe=true&color=blue&limit=20").to_return(response)
+      expect(
+        Record.limited_to(20).blue.available.first.name
+      ).to eq 'Steve'
+    end
+  end
+end

--- a/spec/record/where_chains_spec.rb
+++ b/spec/record/where_chains_spec.rb
@@ -42,7 +42,7 @@ describe LHS::Record do
     end
   end
 
-  context 'multiple paramters' do
+  context 'multiple parameters' do
     before(:each) do
       stub_request(:get, "http://datastore/v2/records/?parameter=last").to_return(response)
     end

--- a/spec/record/where_chains_spec.rb
+++ b/spec/record/where_chains_spec.rb
@@ -5,6 +5,10 @@ describe LHS::Record do
     'http://datastore/v2'
   end
 
+  let(:response) do
+    { body: [{ name: 'Steve' }] }
+  end
+
   before(:each) do
     LHC.config.placeholder('datastore', datastore)
     class Record < LHS::Record
@@ -21,24 +25,35 @@ describe LHS::Record do
   end
 
   context 'where chains' do
-    it 'allows chaining where statements' do
+    before(:each) do
       stub_request(:get, "http://datastore/v2/records/?available=true&color=blue&range=%3E26")
-        .to_return(body: [{ name: 'Steve' }])
-      records = Record.blue.where(range: '>26')
-      records = records.where(available: true)
+        .to_return(response)
+    end
+
+    let(:records) { Record.blue.where(range: '>26').where(available: true) }
+
+    it 'allows chaining where statements' do
       expect(records.class).to eq Record
       expect(records._raw).to eq [{ name: 'Steve' }]
       expect(records.first.uppercase_name).to eq 'STEVE'
-      expect(records.first.name).to eq 'Steve'
+    end
+
+    it 'resolves triggered by method missing' do
+      expect(records._raw).to eq [{ name: 'Steve' }]
+      expect(
+        Record.blue.where(range: '>26', available: true).first.name
+      ).to eq 'Steve'
+    end
+  end
+
+  context 'multiple paramters' do
+    before(:each) do
+      stub_request(:get, "http://datastore/v2/records/?parameter=last").to_return(response)
     end
 
     it 'takes the last value for chains with same name parameters' do
-      stub_request(:get, "http://datastore/v2/records/?parameter=last")
-        .to_return(body: [{ name: 'Steve' }])
       records = Record.where(parameter: 'first').where(parameter: 'last')
-      # initiate the call, the stub will fail if the wrong parameter 'won'
       records.first
     end
-    # TODO: add a test that resolves to method_missing
   end
 end

--- a/spec/record/where_chains_spec.rb
+++ b/spec/record/where_chains_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  let(:datastore) do
+    'http://datastore/v2'
+  end
+
+  before(:each) do
+    LHC.config.placeholder('datastore', datastore)
+    class Record < LHS::Record
+      endpoint ':datastore/records/'
+
+      def self.blue
+        where(color: 'blue')
+      end
+
+      def uppercase_name
+        name.upcase
+      end
+    end
+  end
+
+  context 'where chains' do
+    it 'allows chaining where statements' do
+      stub_request(:get, "http://datastore/v2/records/?available=true&color=blue&range=%3E26")
+        .to_return(body: [{ name: 'Steve' }])
+      records = Record.blue.where(range: '>26')
+      records = records.where(available: true)
+      expect(records.class).to eq Record
+      expect(records._raw).to eq [{ name: 'Steve' }]
+      expect(records.first.uppercase_name).to eq 'STEVE'
+    end
+  end
+end

--- a/spec/record/where_chains_spec.rb
+++ b/spec/record/where_chains_spec.rb
@@ -34,7 +34,7 @@ describe LHS::Record do
 
     it 'takes the last value for chains with same name parameters' do
       stub_request(:get, "http://datastore/v2/records/?parameter=last")
-          .to_return(body: [{ name: 'Steve' }])
+        .to_return(body: [{ name: 'Steve' }])
       records = Record.where(parameter: 'first').where(parameter: 'last')
       # initiate the call, the stub will fail if the wrong parameter 'won'
       records.first

--- a/spec/record/where_chains_spec.rb
+++ b/spec/record/where_chains_spec.rb
@@ -14,10 +14,6 @@ describe LHS::Record do
     class Record < LHS::Record
       endpoint ':datastore/records/'
 
-      def self.blue
-        where(color: 'blue')
-      end
-
       def uppercase_name
         name.upcase
       end
@@ -30,7 +26,7 @@ describe LHS::Record do
         .to_return(response)
     end
 
-    let(:records) { Record.blue.where(range: '>26').where(available: true) }
+    let(:records) { Record.where(color: 'blue').where(range: '>26').where(available: true) }
 
     it 'allows chaining where statements' do
       expect(records.class).to eq Record
@@ -41,7 +37,7 @@ describe LHS::Record do
     it 'resolves triggered by method missing' do
       expect(records._raw).to eq [{ name: 'Steve' }]
       expect(
-        Record.blue.where(range: '>26', available: true).first.name
+        Record.where(color: 'blue').where(range: '>26', available: true).first.name
       ).to eq 'Steve'
     end
   end

--- a/spec/record/where_chains_spec.rb
+++ b/spec/record/where_chains_spec.rb
@@ -29,6 +29,16 @@ describe LHS::Record do
       expect(records.class).to eq Record
       expect(records._raw).to eq [{ name: 'Steve' }]
       expect(records.first.uppercase_name).to eq 'STEVE'
+      expect(records.first.name).to eq 'Steve'
     end
+
+    it 'takes the last value for chains with same name parameters' do
+      stub_request(:get, "http://datastore/v2/records/?parameter=last")
+          .to_return(body: [{ name: 'Steve' }])
+      records = Record.where(parameter: 'first').where(parameter: 'last')
+      # initiate the call, the stub will fail if the wrong parameter 'won'
+      records.first
+    end
+    # TODO: add a test that resolves to method_missing
   end
 end

--- a/spec/record/where_values_hash_spec.rb
+++ b/spec/record/where_values_hash_spec.rb
@@ -17,7 +17,6 @@ describe LHS::Record do
   end
 
   context 'where values hash' do
-
     it 'provides the hash or where parameters that have been requested' do
       stub_request(:get, "http://datastore/v2/records/?available=true&color=blue").to_return(response)
       expect(

--- a/spec/record/where_values_hash_spec.rb
+++ b/spec/record/where_values_hash_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  let(:datastore) do
+    'http://datastore/v2'
+  end
+
+  let(:response) do
+    { body: [{ name: 'Steve' }] }
+  end
+
+  before(:each) do
+    LHC.config.placeholder('datastore', datastore)
+    class Record < LHS::Record
+      endpoint ':datastore/records/'
+    end
+  end
+
+  context 'where values hash' do
+
+    it 'provides the hash or where parameters that have been requested' do
+      stub_request(:get, "http://datastore/v2/records/?available=true&color=blue").to_return(response)
+      expect(
+        Record.where(available: true).where(color: 'blue').where_values_hash
+      ).to eq(available: true, color: 'blue')
+      expect(
+        Record.where(available: true, color: 'red').where(color: 'blue').where_values_hash
+      ).to eq(available: true, color: 'blue')
+    end
+  end
+end


### PR DESCRIPTION
**As lazy evaluated where statements can make tests fail in consuming application I will do a major version increase after merge**

Solves: https://github.com/local-ch/lhs/issues/103

## Scopes / WhereChains

LHS supports WhereChains. That allows you to chain multiple where-queries and helps you organizing query parameters that are used often in scopes (methods):

```ruby
class Record < LHS::Record
  endpoint 'records/'
  endpoint 'records/:id'

  def self.blue
    where(color: 'blue')
  end
end

records = Record.blue.where(available: true)
...
records.where(visible: true).each do |record|
  ...
end
```
The example would fetch the following in the end: `{color: blue, available: true, visible: true}`.