### PR TITLE
! allow to load classes twice: ignore duplicate endpoints, they are n…

### DIFF
--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -47,9 +47,13 @@ class LHS::Record
       end
 
       # Prevent clashing endpoints.
-      def sanity_check(endpoint)
-        placeholders = endpoint.placeholders
-        fail 'Clashing endpoints.' if endpoints.any? { |e| e.placeholders.sort == placeholders.sort }
+      def sanity_check(new_endpoint)
+        endpoints.each do |existing_endpoint|
+          invalid = existing_endpoint.placeholders.sort == new_endpoint.placeholders.sort &&
+            existing_endpoint.url != new_endpoint.url
+          next unless invalid
+          fail "Clashing endpoints! Cannot differentiate between #{existing_endpoint.url} and #{new_endpoint.url}"
+        end
       end
 
       # Computes the url from params

--- a/spec/record/endpoint_misconfiguration_spec.rb
+++ b/spec/record/endpoint_misconfiguration_spec.rb
@@ -10,7 +10,7 @@ describe LHS::Record do
             endpoint ':datastore/v2/reviews'
           end
         }
-      ).to raise_error('Clashing endpoints.')
+      ).to raise_error
       expect(
         lambda {
           class Record < LHS::Record
@@ -18,7 +18,7 @@ describe LHS::Record do
             endpoint ':datastore/v2/:campaign_id/reviews'
           end
         }
-      ).to raise_error('Clashing endpoints.')
+      ).to raise_error
     end
   end
 end

--- a/spec/record/loading_twice_spec.rb
+++ b/spec/record/loading_twice_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'build' do
+    let(:datastore) { 'http://local.ch/v2' }
+
+    it 'is possible to load records twice' do
+      class Feedback < LHS::Record
+        endpoint ':datastore/feedbacks'
+      end
+
+      class Feedback < LHS::Record
+        endpoint ':datastore/feedbacks'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Some consuming applications load the Record classes multiple times. In those cases LHS always raises the `clashing endpoints` error, as it does not ignore real duplicates. We can ignore real duplicates, as the clashing should prevent different endpoints of the same Record to contain the same placeholders!