### PR TITLE
Pagination chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ You can use chainable pagination in combination with query chains:
     endpoint 'http://local.ch/records'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?offset=60&limit=20
+  # http://local.ch/records?offset=40&limit=20&color=blue
 ```
 
 The applied pagination strategy depends on the actual configured pagination, so the interface is the same for all strategies:
@@ -528,7 +528,7 @@ The applied pagination strategy depends on the actual configured pagination, so 
     configuration pagination_strategy: 'page'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?page=3&limit=20
+  # http://local.ch/records?page=3&limit=20&color=blue
 ```
 
 ```ruby
@@ -537,7 +537,7 @@ The applied pagination strategy depends on the actual configured pagination, so 
     configuration pagination_strategy: 'start'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?start=61&limit=20
+  # http://local.ch/records?start=41&limit=20&color=blue
 ```
 
 ### Partial Kaminari support

--- a/README.md
+++ b/README.md
@@ -510,7 +510,35 @@ In case of paginated resources it's important to know the difference between [co
 
 ### Pagination Chains
 
-...
+You can use chainable pagination in combination with query chains:
+
+```ruby
+  class Record < LHS::Record
+    endpoint 'http://local.ch/records'
+  end
+  Record.page(3).per(20).where(color: 'blue')
+  # http://local.ch/records?offset=60&limit=20
+```
+
+The applied pagination strategy depends on the actual configured pagination, so the interface is the same for all strategies:
+
+```ruby
+  class Record < LHS::Record
+    endpoint 'http://local.ch/records'
+    configuration pagination_strategy: 'page'
+  end
+  Record.page(3).per(20).where(color: 'blue')
+  # http://local.ch/records?page=3&limit=20
+```
+
+```ruby
+  class Record < LHS::Record
+    endpoint 'http://local.ch/records'
+    configuration pagination_strategy: 'start'
+  end
+  Record.page(3).per(20).where(color: 'blue')
+  # http://local.ch/records?page=61&limit=20
+```
 
 ### Partial Kaminari support
 
@@ -523,8 +551,7 @@ The kaminari’s page parameter is in params[:page]. For example, you can use ka
 params[:page] = 0 if params[:page].nil?
 page = params[:page].to_i
 limit = 100
-offset = (page - 1) * limit
-@items = Record.where({ limit: limit, offset: offset }))
+@items = Record.page(page).per(limit)
 ```
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -540,6 +540,8 @@ The applied pagination strategy depends on the actual configured pagination, so 
   # http://local.ch/records?start=41&limit=20&color=blue
 ```
 
+`limit(argument)` is an alias for `per(argument)`. Take notice that `limit` without argument instead, makes the query resolve and provides the current limit from the responds.
+
 ### Partial Kaminari support
 
 LHS implements an interface that makes it partially working with Kaminari.

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ unless user.valid?
 end
 ```
 
-## How to work with paginated APIs
+## Pagination
 
 LHS supports paginated APIs and it also supports various pagination strategies and by providing configuration possibilities.
 
@@ -507,6 +507,10 @@ end
 `total_key` key used to determine the total amount of items (e.g. `total`, `totalResults`, etc.).
 
 In case of paginated resources it's important to know the difference between [count vs. length](#count-vs-length)
+
+### Pagination Chains
+
+...
 
 ### Partial Kaminari support
 

--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ The applied pagination strategy depends on the actual configured pagination, so 
     configuration pagination_strategy: 'start'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?page=61&limit=20
+  # http://local.ch/records?start=61&limit=20
 ```
 
 ### Partial Kaminari support

--- a/lib/lhs/concerns/record/all.rb
+++ b/lib/lhs/concerns/record/all.rb
@@ -12,7 +12,7 @@ class LHS::Record
       # for the following pages and concatenate all the results in order to return
       # all the objects for a given resource.
       def all(params = {})
-        limit = params[limit_key] || Pagination::DEFAULT_LIMIT
+        limit = params[limit_key] || LHS::Pagination::DEFAULT_LIMIT
         data = request(params: params.merge(limit_key => limit))
         request_all_the_rest(data, params) if paginated?(data._raw)
         data._record.new(LHS::Data.new(data, nil, self))

--- a/lib/lhs/concerns/record/all.rb
+++ b/lib/lhs/concerns/record/all.rb
@@ -5,8 +5,6 @@ class LHS::Record
   module All
     extend ActiveSupport::Concern
 
-    DEFAULT_LIMIT = 100
-
     module ClassMethods
       # Should be an edge case but sometimes all objects from a certain resource
       # are required. In this case we load the first page with the default max limit,
@@ -14,7 +12,7 @@ class LHS::Record
       # for the following pages and concatenate all the results in order to return
       # all the objects for a given resource.
       def all(params = {})
-        limit = params[limit_key] || DEFAULT_LIMIT
+        limit = params[limit_key] || Pagination::DEFAULT_LIMIT
         data = request(params: params.merge(limit_key => limit))
         request_all_the_rest(data, params) if paginated?(data._raw)
         data._record.new(LHS::Data.new(data, nil, self))

--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -20,7 +20,7 @@ class LHS::Record
       def find_in_batches(options = {})
         fail 'No block given' unless block_given?
         start = options[:start] || 1
-        batch_size = options[:batch_size] || Pagination::DEFAULT_LIMIT
+        batch_size = options[:batch_size] || LHS::Pagination::DEFAULT_LIMIT
         params = options[:params] || {}
         loop do # as suggested by Matz
           data = request(params: params.merge(limit: batch_size, offset: start))

--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -20,7 +20,7 @@ class LHS::Record
       def find_in_batches(options = {})
         fail 'No block given' unless block_given?
         start = options[:start] || 1
-        batch_size = options[:batch_size] || 100
+        batch_size = options[:batch_size] || Pagination::DEFAULT_LIMIT
         params = options[:params] || {}
         loop do # as suggested by Matz
           data = request(params: params.merge(limit: batch_size, offset: start))

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -26,6 +26,10 @@ class LHS::Record
       def per(limit)
         Chain.new(self, Pagination.new(per: limit))
       end
+      
+      def limit(argument = nil)
+        Chain.new(self, Pagination.new(per: argument))
+      end
     end
 
     # Link: A part of a chain
@@ -121,6 +125,11 @@ class LHS::Record
 
       def per(per)
         push Pagination.new(per: per)
+      end
+
+      def limit(argument = nil)
+        return resolve.limit if argument.blank?
+        push Pagination.new(per: argument)
       end
 
       def find(args)

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -26,6 +26,10 @@ class LHS::Record
         @hash = hash
       end
 
+      def [](parameter)
+        @hash[parameter]
+      end
+
       def to_hash
         @hash
       end
@@ -107,8 +111,8 @@ class LHS::Record
         push Pagination.new(page: page)
       end
 
-      def limit(limit)
-        push Pagination.new(limit: limit)
+      def per(per)
+        push Pagination.new(per: per)
       end
 
       def find(args)
@@ -172,19 +176,21 @@ class LHS::Record
       end
 
       def chain_pagination
-        merge_links resolve_pagination @chain.select { |link| link.is_a? Pagination }
+        resolve_pagination @chain.select { |link| link.is_a? Pagination }
       end
 
       def resolve_pagination(links)
+        return {} if links.empty?
         page = 1
-        limit = Pagination::DEFAULT_LIMIT
+        per = LHS::Pagination::DEFAULT_LIMIT
         links.each do |link|
           page = link[:page] if link[:page].present?
-          limit = link[:limit] if link[:limit].present?
+          per = link[:per] if link[:per].present?
         end
+        pagination = @record_class.pagination_class
         {
-          @record_class.pagination_key => page,
-          @record_class.limit_key => limit
+          @record_class.pagination_key => pagination.page_to_offset(page, per),
+          @record_class.limit_key => per
         }
       end
 

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -18,6 +18,14 @@ class LHS::Record
       def options(hash = nil)
         Chain.new(self, Option.new(hash))
       end
+
+      def page(page)
+        Chain.new(self, Pagination.new(page: page))
+      end
+
+      def per(limit)
+        Chain.new(self, Pagination.new(per: limit))
+      end
     end
 
     # Link: A part of a chain

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -26,7 +26,7 @@ class LHS::Record
       def per(limit)
         Chain.new(self, Pagination.new(per: limit))
       end
-      
+
       def limit(argument = nil)
         Chain.new(self, Pagination.new(per: argument))
       end

--- a/lib/lhs/concerns/record/pagination.rb
+++ b/lib/lhs/concerns/record/pagination.rb
@@ -13,7 +13,8 @@ class LHS::Record
 
     module ClassMethods
       def pagination(data)
-        case data._record.pagination_strategy.to_sym
+        pagination_class
+        case pagination_strategy.to_sym
         when :page
           PagePagination.new(data)
         when :start

--- a/lib/lhs/concerns/record/pagination.rb
+++ b/lib/lhs/concerns/record/pagination.rb
@@ -12,7 +12,6 @@ class LHS::Record
     end
 
     module ClassMethods
-
       def pagination_class
         case pagination_strategy.to_sym
         when :page

--- a/lib/lhs/concerns/record/pagination.rb
+++ b/lib/lhs/concerns/record/pagination.rb
@@ -12,16 +12,20 @@ class LHS::Record
     end
 
     module ClassMethods
-      def pagination(data)
-        pagination_class
+
+      def pagination_class
         case pagination_strategy.to_sym
         when :page
-          PagePagination.new(data)
+          LHS::PagePagination
         when :start
-          StartPagination.new(data)
+          LHS::StartPagination
         else
-          OffsetPagination.new(data)
+          LHS::OffsetPagination
         end
+      end
+
+      def pagination(data)
+        pagination_class.new(data)
       end
     end
   end

--- a/lib/lhs/pagination.rb
+++ b/lib/lhs/pagination.rb
@@ -1,6 +1,8 @@
 # Pagination is used to navigate paginateable collections
 class Pagination
 
+  DEFAULT_LIMIT = 100
+
   delegate :_record, to: :data
   attr_accessor :data
 

--- a/lib/lhs/pagination.rb
+++ b/lib/lhs/pagination.rb
@@ -92,7 +92,7 @@ class LHS::StartPagination < LHS::Pagination
   end
 
   def self.page_to_offset(page, limit = LHS::Pagination::DEFAULT_LIMIT)
-    page * limit + 1
+    (page - 1) * limit + 1
   end
 end
 
@@ -107,6 +107,6 @@ class LHS::OffsetPagination < LHS::Pagination
   end
 
   def self.page_to_offset(page, limit = LHS::Pagination::DEFAULT_LIMIT)
-    page * limit
+    (page - 1) * limit
   end
 end

--- a/lib/lhs/pagination.rb
+++ b/lib/lhs/pagination.rb
@@ -65,7 +65,7 @@ class LHS::Pagination
     (total.to_f / limit).ceil
   end
 
-  def self.page_to_offset(page, limit)
+  def self.page_to_offset(page, _limit)
     page
   end
 end

--- a/lib/lhs/pagination.rb
+++ b/lib/lhs/pagination.rb
@@ -1,5 +1,5 @@
 # Pagination is used to navigate paginateable collections
-class Pagination
+class LHS::Pagination
 
   DEFAULT_LIMIT = 100
 
@@ -20,7 +20,7 @@ class Pagination
   end
 
   def limit
-    data._raw[_record.limit_key.to_sym] || LHS::Record::DEFAULT_LIMIT
+    data._raw[_record.limit_key.to_sym] || LHS::Pagination::DEFAULT_LIMIT
   end
 
   def offset
@@ -64,9 +64,13 @@ class Pagination
   def total_pages
     (total.to_f / limit).ceil
   end
+
+  def self.page_to_offset(page, limit)
+    page
+  end
 end
 
-class PagePagination < Pagination
+class LHS::PagePagination < LHS::Pagination
 
   def current_page
     offset
@@ -75,10 +79,9 @@ class PagePagination < Pagination
   def next_offset
     current_page + 1
   end
-
 end
 
-class StartPagination < Pagination
+class LHS::StartPagination < LHS::Pagination
 
   def current_page
     (offset + limit - 1) / limit
@@ -88,9 +91,12 @@ class StartPagination < Pagination
     offset + limit
   end
 
+  def self.page_to_offset(page, limit = LHS::Pagination::DEFAULT_LIMIT)
+    page * limit + 1
+  end
 end
 
-class OffsetPagination < Pagination
+class LHS::OffsetPagination < LHS::Pagination
 
   def current_page
     (offset + limit) / limit
@@ -100,4 +106,7 @@ class OffsetPagination < Pagination
     offset + limit
   end
 
+  def self.page_to_offset(page, limit = LHS::Pagination::DEFAULT_LIMIT)
+    page * limit
+  end
 end

--- a/spec/pagination/pages_left_spec.rb
+++ b/spec/pagination/pages_left_spec.rb
@@ -8,7 +8,7 @@ describe LHS::Record do
     LHS::Data.new(data_hash, nil, Record)
   end
 
-  let(:pagination) { OffsetPagination.new(data) }
+  let(:pagination) { LHS::OffsetPagination.new(data) }
 
   before(:each) do
     class Record < LHS::Record

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -20,6 +20,15 @@ describe LHS::Record do
         Record.where(color: 'blue').per(10).page(3).first
         Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
       end
+
+      it 'allows to start chains with pagination methods' do
+        stub_request(:get, "http://local.ch/records?color=blue&offset=300&limit=100").to_return(body: [].to_json)
+        Record.page(3).where(color: 'blue').first
+        stub_request(:get, "http://local.ch/records?color=blue&offset=30&limit=10").to_return(body: [].to_json)
+        Record.page(3).per(10).where(color: 'blue').first
+        Record.per(10).page(3).where(color: 'blue').first
+        Record.per(20).page(5).where(color: 'blue').per(10).page(3).first
+      end
     end
 
     context 'start pagination' do

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -38,6 +38,13 @@ describe LHS::Record do
         Record.per(10).page("").first
         expect(request).to have_been_made.times(2)
       end
+
+      it 'provides limit as alias for per' do
+        request = stub_request(:get, "http://local.ch/records?limit=10&offset=0").to_return(body: [].to_json)
+        Record.limit(10).first
+        Record.page("").limit(10).first
+        expect(request).to have_been_made.times(2)
+      end
     end
 
     context 'start pagination' do

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -4,19 +4,60 @@ describe LHS::Record do
 
   context 'pagination chain' do
 
-    before(:each) do
-      class Record < LHS::Record
-        endpoint 'http://local.ch/records'
-        endpoint 'http://local.ch/records/:id'
+    context 'default pagination (offset)' do
+      before(:each) do
+        class Record < LHS::Record
+          endpoint 'http://local.ch/records'
+          endpoint 'http://local.ch/records/:id'
+        end
+      end
+
+      it 'allows to chain pagination methods' do
+        stub_request(:get, "http://local.ch/records?color=blue&offset=300&limit=100").to_return(body: [].to_json)
+        Record.where(color: 'blue').page(3).first
+        stub_request(:get, "http://local.ch/records?color=blue&offset=30&limit=10").to_return(body: [].to_json)
+        Record.where(color: 'blue').page(3).per(10).first
+        Record.where(color: 'blue').per(10).page(3).first
+        Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
       end
     end
 
-    it 'allows to chain pagination methods' do
-      stub_request(:get, "http://local.ch/records?color=blue&offset=300&limit=100").to_return(body: [].to_json)
-      Record.where(color: 'blue').page(3).first
-      stub_request(:get, "http://local.ch/records?color=blue&offset=30&limit=10").to_return(body: [].to_json)
-      Record.where(color: 'blue').page(3).limit(10).first
-      Record.where(color: 'blue').limit(10).page(3).first
+    context 'start pagination' do
+      before(:each) do
+        class Record < LHS::Record
+          configuration pagination_strategy: 'start', pagination_key: 'start'
+          endpoint 'http://local.ch/records'
+          endpoint 'http://local.ch/records/:id'
+        end
+      end
+
+      it 'allows to chain pagination methods' do
+        stub_request(:get, "http://local.ch/records?color=blue&start=301&limit=100").to_return(body: [].to_json)
+        Record.where(color: 'blue').page(3).first
+        stub_request(:get, "http://local.ch/records?color=blue&start=31&limit=10").to_return(body: [].to_json)
+        Record.where(color: 'blue').page(3).per(10).first
+        Record.where(color: 'blue').per(10).page(3).first
+        Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
+      end
+    end
+
+    context 'page pagination' do
+      before(:each) do
+        class Record < LHS::Record
+          configuration pagination_strategy: 'page', pagination_key: 'page'
+          endpoint 'http://local.ch/records'
+          endpoint 'http://local.ch/records/:id'
+        end
+      end
+
+      it 'allows to chain pagination methods' do
+        stub_request(:get, "http://local.ch/records?color=blue&page=3&limit=100").to_return(body: [].to_json)
+        Record.where(color: 'blue').page(3).first
+        stub_request(:get, "http://local.ch/records?color=blue&page=3&limit=10").to_return(body: [].to_json)
+        Record.where(color: 'blue').page(3).per(10).first
+        Record.where(color: 'blue').per(10).page(3).first
+        Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
+      end
     end
   end
 end

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -11,21 +11,27 @@ describe LHS::Record do
       end
 
       it 'allows to chain pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&offset=300&limit=100").to_return(body: [].to_json)
+        stub_request(:get, "http://local.ch/records?color=blue&offset=200&limit=100").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).first
-        stub_request(:get, "http://local.ch/records?color=blue&offset=30&limit=10").to_return(body: [].to_json)
+        stub_request(:get, "http://local.ch/records?color=blue&offset=20&limit=10").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).per(10).first
         Record.where(color: 'blue').per(10).page(3).first
         Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
       end
 
       it 'allows to start chains with pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&offset=300&limit=100").to_return(body: [].to_json)
+        stub_request(:get, "http://local.ch/records?color=blue&offset=200&limit=100").to_return(body: [].to_json)
         Record.page(3).where(color: 'blue').first
-        stub_request(:get, "http://local.ch/records?color=blue&offset=30&limit=10").to_return(body: [].to_json)
+        stub_request(:get, "http://local.ch/records?color=blue&offset=20&limit=10").to_return(body: [].to_json)
         Record.page(3).per(10).where(color: 'blue').first
         Record.per(10).page(3).where(color: 'blue').first
         Record.per(20).page(5).where(color: 'blue').per(10).page(3).first
+      end
+
+      it 'defaults page to 1' do
+        stub_request(:get, "http://local.ch/records?limit=10&offset=0").to_return(body: [].to_json)
+        Record.per(10).first
+        Record.per(10).page("").first
       end
     end
 
@@ -39,9 +45,9 @@ describe LHS::Record do
       end
 
       it 'allows to chain pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&start=301&limit=100").to_return(body: [].to_json)
+        stub_request(:get, "http://local.ch/records?color=blue&start=201&limit=100").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).first
-        stub_request(:get, "http://local.ch/records?color=blue&start=31&limit=10").to_return(body: [].to_json)
+        stub_request(:get, "http://local.ch/records?color=blue&start=21&limit=10").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).per(10).first
         Record.where(color: 'blue').per(10).page(3).first
         Record.where(color: 'blue').per(20).page(5).per(10).page(3).first

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 describe LHS::Record do
-
   context 'pagination chain' do
-
     context 'default pagination (offset)' do
       before(:each) do
         class Record < LHS::Record

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe LHS::Record do
+
+  context 'pagination chain' do
+
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://local.ch/records'
+        endpoint 'http://local.ch/records/:id'
+      end
+    end
+
+    it 'allows to chain pagination methods' do
+      stub_request(:get, "http://local.ch/records?color=blue&offset=300&limit=100").to_return(body: [].to_json)
+      Record.where(color: 'blue').page(3).first
+      stub_request(:get, "http://local.ch/records?color=blue&offset=30&limit=10").to_return(body: [].to_json)
+      Record.where(color: 'blue').page(3).limit(10).first
+      Record.where(color: 'blue').limit(10).page(3).first
+    end
+  end
+end

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -11,27 +11,32 @@ describe LHS::Record do
       end
 
       it 'allows to chain pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&offset=200&limit=100").to_return(body: [].to_json)
+        request = stub_request(:get, "http://local.ch/records?color=blue&offset=200&limit=100").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).first
-        stub_request(:get, "http://local.ch/records?color=blue&offset=20&limit=10").to_return(body: [].to_json)
+        expect(request).to have_been_made.times(1)
+        request = stub_request(:get, "http://local.ch/records?color=blue&offset=20&limit=10").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).per(10).first
         Record.where(color: 'blue').per(10).page(3).first
         Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
+        expect(request).to have_been_made.times(3)
       end
 
       it 'allows to start chains with pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&offset=200&limit=100").to_return(body: [].to_json)
+        request = stub_request(:get, "http://local.ch/records?color=blue&offset=200&limit=100").to_return(body: [].to_json)
         Record.page(3).where(color: 'blue').first
-        stub_request(:get, "http://local.ch/records?color=blue&offset=20&limit=10").to_return(body: [].to_json)
+        expect(request).to have_been_made.times(1)
+        request = stub_request(:get, "http://local.ch/records?color=blue&offset=20&limit=10").to_return(body: [].to_json)
         Record.page(3).per(10).where(color: 'blue').first
         Record.per(10).page(3).where(color: 'blue').first
         Record.per(20).page(5).where(color: 'blue').per(10).page(3).first
+        expect(request).to have_been_made.times(3)
       end
 
       it 'defaults page to 1' do
-        stub_request(:get, "http://local.ch/records?limit=10&offset=0").to_return(body: [].to_json)
+        request = stub_request(:get, "http://local.ch/records?limit=10&offset=0").to_return(body: [].to_json)
         Record.per(10).first
         Record.per(10).page("").first
+        expect(request).to have_been_made.times(2)
       end
     end
 
@@ -45,12 +50,14 @@ describe LHS::Record do
       end
 
       it 'allows to chain pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&start=201&limit=100").to_return(body: [].to_json)
+        request = stub_request(:get, "http://local.ch/records?color=blue&start=201&limit=100").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).first
-        stub_request(:get, "http://local.ch/records?color=blue&start=21&limit=10").to_return(body: [].to_json)
+        expect(request).to have_been_made.times(1)
+        request = stub_request(:get, "http://local.ch/records?color=blue&start=21&limit=10").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).per(10).first
         Record.where(color: 'blue').per(10).page(3).first
         Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
+        expect(request).to have_been_made.times(3)
       end
     end
 
@@ -64,12 +71,14 @@ describe LHS::Record do
       end
 
       it 'allows to chain pagination methods' do
-        stub_request(:get, "http://local.ch/records?color=blue&page=3&limit=100").to_return(body: [].to_json)
+        request = stub_request(:get, "http://local.ch/records?color=blue&page=3&limit=100").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).first
-        stub_request(:get, "http://local.ch/records?color=blue&page=3&limit=10").to_return(body: [].to_json)
+        expect(request).to have_been_made.times(1)
+        request = stub_request(:get, "http://local.ch/records?color=blue&page=3&limit=10").to_return(body: [].to_json)
         Record.where(color: 'blue').page(3).per(10).first
         Record.where(color: 'blue').per(10).page(3).first
         Record.where(color: 'blue').per(20).page(5).per(10).page(3).first
+        expect(request).to have_been_made.times(3)
       end
     end
   end


### PR DESCRIPTION
### Pagination Chains

You can use chainable pagination in combination with query chains:

```ruby
  class Record < LHS::Record
    endpoint 'http://local.ch/records'
  end
  Record.page(3).per(20).where(color: 'blue')
  # http://local.ch/records?offset=40&limit=20
```

The applied pagination strategy depends on the actual configured pagination, so the interface is the same for all strategies:

```ruby
  class Record < LHS::Record
    endpoint 'http://local.ch/records'
    configuration pagination_strategy: 'page'
  end
  Record.page(3).per(20).where(color: 'blue')
  # http://local.ch/records?page=3&limit=20
```

```ruby
  class Record < LHS::Record
    endpoint 'http://local.ch/records'
    configuration pagination_strategy: 'start'
  end
  Record.page(3).per(20).where(color: 'blue')
  # http://local.ch/records?start=41&limit=20
```