### PR TITLE
+ methods to navigate data

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,18 @@ If no record is found, `nil` is returned.
 
 `first!` raises LHC::NotFound if nothing was found.
 
+## Navigate data
+
+After fetching [single](#find-single-records) or [multiple](#find-multiple-records) records you can navigate the received data with ease.
+
+```ruby
+  records = Record.where(color: 'blue')
+  records.collection? # true
+  record = records.first
+  record.item? # true
+  record.parent == records # true
+```
+
 ## Request based options
 
 You can apply options to the request chain. Those options will be forwarded to the request perfomed by the chain/query.

--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -24,6 +24,10 @@ class LHS::Collection < LHS::Proxy
     Collection.new(raw, _data, _record)
   end
 
+  def collection?
+    true
+  end
+
   protected
 
   def method_missing(name, *args, &block)

--- a/lib/lhs/concerns/data/equality.rb
+++ b/lib/lhs/concerns/data/equality.rb
@@ -1,0 +1,12 @@
+require 'active_support'
+
+class LHS::Data
+
+  module Equality
+    extend ActiveSupport::Concern
+
+    def ==(other)
+      _raw == other.try(:_raw)
+    end
+  end
+end

--- a/lib/lhs/concerns/record/equality.rb
+++ b/lib/lhs/concerns/record/equality.rb
@@ -1,0 +1,12 @@
+require 'active_support'
+
+class LHS::Record
+
+  module Equality
+    extend ActiveSupport::Concern
+
+    def ==(other)
+      _raw == other.try(:_raw)
+    end
+  end
+end

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -3,6 +3,7 @@ Dir[File.dirname(__FILE__) + '/concerns/data/*.rb'].each { |file| require file }
 
 # Data provides functionalities to accesses information
 class LHS::Data
+  include Equality
   include Json
 
   delegate :instance_methods, :items_key, :limit_key, :total_key, :pagination_key, to: :class
@@ -32,6 +33,14 @@ class LHS::Data
     root
   end
 
+  def parent
+    if _parent && _parent._record
+      _parent._record.new(_parent)
+    else
+      _parent
+    end
+  end
+
   def class
     _root._record
   end
@@ -44,6 +53,14 @@ class LHS::Data
 
   def root_item?
     root_item == self
+  end
+
+  def collection?
+    _proxy.is_a? LHS::Collection
+  end
+
+  def item?
+    _proxy.is_a? LHS::Item
   end
 
   protected

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -16,6 +16,10 @@ class LHS::Item < LHS::Proxy
 
   delegate :_raw, to: :_data
 
+  def item?
+    true
+  end
+
   protected
 
   def method_missing(name, *args, &_block)

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -6,6 +6,7 @@ class LHS::Record
   include Chainable
   include Configuration
   include Create
+  include Equality
   include Endpoints
   include Find
   include FindBy
@@ -19,6 +20,7 @@ class LHS::Record
 
   delegate :_proxy, to: :_data
   delegate :_endpoint, to: :_data
+  delegate :select, to: :_data
 
   def initialize(data = nil)
     data = LHS::Data.new({}, nil, self.class) unless data
@@ -42,7 +44,7 @@ class LHS::Record
   protected
 
   def method_missing(name, *args, &block)
-    _data._proxy.send(name, *args, &block)
+    _data.send(name, *args, &block)
   end
 
   def respond_to_missing?(name, include_all = false)

--- a/spec/data/equality_spec.rb
+++ b/spec/data/equality_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 describe LHS::Data do
-
   context 'equality' do
-
     before(:each) do
       class Record < LHS::Record
         endpoint 'http://local.ch/records'
@@ -13,7 +11,7 @@ describe LHS::Data do
     let(:raw) do
       { name: 'Steve' }
     end
-    
+
     it 'is equal when two data objects share the same raw data' do
       expect(
         LHS::Data.new(raw, nil, Record)

--- a/spec/data/equality_spec.rb
+++ b/spec/data/equality_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe LHS::Data do
+
+  context 'equality' do
+
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://local.ch/records'
+      end
+    end
+
+    let(:raw) do
+      { name: 'Steve' }
+    end
+    
+    it 'is equal when two data objects share the same raw data' do
+      expect(
+        LHS::Data.new(raw, nil, Record)
+      ).to eq LHS::Data.new(raw, nil, Record)
+    end
+  end
+end

--- a/spec/data/is_item_or_collection_spec.rb
+++ b/spec/data/is_item_or_collection_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe LHS::Data do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://local.ch/records'
+    end
+  end
+
+  let(:item) do
+    {
+      customer: {
+        addresses: [
+          {
+            first_line: 'Bachstr. 6'
+          }
+        ]
+      }
+    }
+  end
+
+  let(:data) do
+    LHS::Data.new(
+      {
+        href: 'http://local.ch/records',
+        items: [item]
+      }, nil, Record)
+  end
+
+  it 'provides the information which type of proxy data ist' do
+    expect(data.collection?).to eq true
+    expect(data.first.item?).to eq true
+    expect(data.first.customer.item?).to eq true
+    expect(data.first.customer.addresses.collection?).to eq true
+    expect(data.first.customer.addresses.first.item?).to eq true
+  end
+end

--- a/spec/data/parent_spec.rb
+++ b/spec/data/parent_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe LHS::Data do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://local.ch/records'
+    end
+  end
+
+  let(:item) do
+    {
+      customer: {
+        address: {
+          first_line: 'Bachstr. 6'
+        }
+      }
+    }
+  end
+
+  let(:data) do
+    LHS::Data.new(
+      {
+        href: 'http://local.ch/records',
+        items: [item]
+      }, nil, Record)
+  end
+
+  it 'possible to navigate the parent' do
+    expect(
+      data.first.customer.address.parent
+    ).to eq data.first.customer
+    expect(
+      data.first.customer.address.parent.parent
+    ).to eq data.first
+  end
+end

--- a/spec/record/equality_spec.rb
+++ b/spec/record/equality_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe LHS::Record do
+
+  context 'equality' do
+
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://local.ch/records'
+      end
+    end
+
+    let(:raw) do
+      { name: 'Steve' }
+    end
+
+    def record
+      LHS::Record.new LHS::Data.new(raw, nil, Record)
+    end
+
+    it 'is equal when two data objects share the same raw data' do
+      expect(
+        record
+      ).to eq record
+    end
+  end
+end

--- a/spec/record/equality_spec.rb
+++ b/spec/record/equality_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 describe LHS::Record do
-
   context 'equality' do
-
     before(:each) do
       class Record < LHS::Record
         endpoint 'http://local.ch/records'


### PR DESCRIPTION
+ `collection?` to check if data is a collection
+ `item?` to check if data is an item
+ `parent` to navigate up
+ equality for data and record in order to make things comparable

! not bypassing data anymore when forwarding data from record to proxy
! keeping the special case for rubys native select (which has to be solved with delegation)