### PR TITLE
Fix pagination string case

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,10 +559,7 @@ The kaminari’s page parameter is in params[:page]. For example, you can use ka
 
 ```ruby
 # controller
-params[:page] = 0 if params[:page].nil?
-page = params[:page].to_i
-limit = 100
-@items = Record.page(page).per(limit)
+@items = Record.page(params[:page]).per(100)
 ```
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ records.where(available: true).each do |record|
   ...
 end
 ```
+
 The example would fetch records with the following parameters: `{color: blue, available: true}`.
 
 ## Where values hash
@@ -371,7 +372,7 @@ end
 
 Nested records (in nested data) are automaticaly casted when the href matches any defined endpoint of any LHS::Record.
 
-```
+```ruby
 class Place < LHS::Record
   endpoint ':datastore/v2/places'
 
@@ -394,7 +395,7 @@ If automatic-detection of nested records does not work, make sure your LHS::Reco
 
 You can change attributes of LHS::Records:
 
-```
+```ruby
   record = Feedback.find(id: 'z12f-3asm3ngals')
   rcord.recommended = false
 ```
@@ -435,7 +436,7 @@ In order to validate LHS::Records before persisting them, you can use the `valid
 
 The specific endpoint has to support validations with the `persist=false` parameter. The endpoint has to be enabled (opt-in) for validations in the service configuration.
 
-```
+```ruby
 class User < LHS::Record
   endpoint ':datastore/v2/users', validates: true
 end
@@ -523,30 +524,30 @@ You can use chainable pagination in combination with query chains:
 
 ```ruby
   class Record < LHS::Record
-    endpoint 'http://local.ch/records'
+    endpoint ':datastore/records'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?offset=40&limit=20&color=blue
+  # /records?offset=40&limit=20&color=blue
 ```
 
 The applied pagination strategy depends on the actual configured pagination, so the interface is the same for all strategies:
 
 ```ruby
   class Record < LHS::Record
-    endpoint 'http://local.ch/records'
+    endpoint ':datastore/records'
     configuration pagination_strategy: 'page'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?page=3&limit=20&color=blue
+  # /records?page=3&limit=20&color=blue
 ```
 
 ```ruby
   class Record < LHS::Record
-    endpoint 'http://local.ch/records'
+    endpoint ':datastore/records'
     configuration pagination_strategy: 'start'
   end
   Record.page(3).per(20).where(color: 'blue')
-  # http://local.ch/records?start=41&limit=20&color=blue
+  # /records?start=41&limit=20&color=blue
 ```
 
 `limit(argument)` is an alias for `per(argument)`. Take notice that `limit` without argument instead, makes the query resolve and provides the current limit from the responds.
@@ -569,7 +570,7 @@ The kaminari’s page parameter is in params[:page]. For example, you can use ka
 
 ## form_for Helper
 Rails `form_for` view-helper can be used in combination with instances of LHS::Record to autogenerate forms:
-```
+```ruby
 <%= form_for(@instance, url: '/create') do |f| %>
   <%= f.text_field :name %>
   <%= f.text_area :text %>

--- a/lib/lhs/pagination.rb
+++ b/lib/lhs/pagination.rb
@@ -66,7 +66,7 @@ class LHS::Pagination
   end
 
   def self.page_to_offset(page, _limit)
-    page
+    page.to_i
   end
 end
 
@@ -92,7 +92,7 @@ class LHS::StartPagination < LHS::Pagination
   end
 
   def self.page_to_offset(page, limit = LHS::Pagination::DEFAULT_LIMIT)
-    (page - 1) * limit + 1
+    (page.to_i - 1) * limit.to_i + 1
   end
 end
 
@@ -107,6 +107,6 @@ class LHS::OffsetPagination < LHS::Pagination
   end
 
   def self.page_to_offset(page, limit = LHS::Pagination::DEFAULT_LIMIT)
-    (page - 1) * limit
+    (page.to_i - 1) * limit.to_i
   end
 end

--- a/spec/record/pagination_chain_spec.rb
+++ b/spec/record/pagination_chain_spec.rb
@@ -45,6 +45,13 @@ describe LHS::Record do
         Record.page("").limit(10).first
         expect(request).to have_been_made.times(2)
       end
+
+      it 'also works with strings' do
+        request = stub_request(:get, "http://local.ch/records?limit=10&offset=0").to_return(body: [].to_json)
+        Record.limit('10').first
+        Record.page('1').limit('10').first
+        expect(request).to have_been_made.times(2)
+      end
     end
 
     context 'start pagination' do


### PR DESCRIPTION
Fixes cases where pagination arguments have been passed as strings
```
Record.page(params[:page])
```
Params are usually strings.