### PR TITLE
! improve data inspect

### DIFF
--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -74,6 +74,11 @@ class LHS::Data
       _proxy.respond_to?(name, include_all)
   end
 
+  def inspect_with_focus
+    _raw
+  end
+  alias_method_chain :inspect, :focus
+
   private
 
   def collection_proxy?(input)

--- a/spec/data/inspect_spec.rb
+++ b/spec/data/inspect_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe LHS::Data do
+  context 'equality' do
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://local.ch/records'
+      end
+    end
+
+    let(:raw) do
+      { name: 'Steve' }
+    end
+
+    let(:data) do
+      LHS::Data.new(raw, nil, Record)
+    end
+
+    it 'provides inspect method that is focused on the raw data' do
+      expect(data.inspect).to eq raw
+      expect(data.inspect_without_focus).to include 'LHS::Data'
+    end
+  end
+end


### PR DESCRIPTION
Data on the terminal now looks directly like raw data:

```ruby
data = Record.find(1)
data # { name: 'Steve' }
```

Before: 
```ruby
data
#<LHS::Data:0x007fe67a64f600 @_raw={:name=>\"Steve\"}, @_parent=nil, @_record=Record, @_proxy=#<LHS::Item:0x007fe67a64f420 @_data={:name=>\"Steve\"}, @_loaded=false>, @_request=nil, @_endpoint=nil>
```

On one hand this was leaking internals to the outside, second it makes people use `_raw` all over the place, but they shouldn't.

For internal reasons `inspect_without_focus` stays around.