### PR TITLE
Keep the headers passed via options to save

### DIFF
--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -25,7 +25,11 @@ class LHS::Item < LHS::Proxy
         endpoint.remove_interpolated_params!(data)
       end
 
-      data = record.request(options.merge(method: :post, url: url, body: data.to_json, headers: { 'Content-Type' => 'application/json' }))
+      options = options.merge(method: :post, url: url, body: data.to_json)
+      options[:headers] ||= {}
+      options[:headers].merge!('Content-Type' => 'application/json')
+
+      data = record.request(options)
       _data.merge_raw!(data)
       true
     end

--- a/spec/item/save_spec.rb
+++ b/spec/item/save_spec.rb
@@ -50,5 +50,17 @@ describe LHS::Item do
         .to_return(status: 500)
       expect(-> { item.save! }).to raise_error LHC::ServerError
     end
+
+    it 'keeps header psassed in the options' do
+      headers = { 'Stats' => 'first-access' }
+      request = stub_request(:post, item.href)
+        .with(
+          body: item._raw.to_json,
+          headers: headers)
+        .to_return(status: 200, body: item._raw.to_json)
+
+      item.save!(headers: headers)
+      expect(request).to have_been_requested
+    end
   end
 end


### PR DESCRIPTION
In the current implementation `save!` method always overwrites the headers passed via the options.
This PR fixes that misbehaviour.