### PR TITLE
! pick correct endpoint when validating and record contains embeded href

### DIFF
--- a/lib/lhs/concerns/item/validation.rb
+++ b/lib/lhs/concerns/item/validation.rb
@@ -47,7 +47,7 @@ class LHS::Item < LHS::Proxy
     end
 
     def params_from_embeded_href
-      return {} unless _data.href
+      return {} if !_data.href || !embeded_endpoint
       LHC::Endpoint.values_as_params(embeded_endpoint.url, _data.href)
     end
   end

--- a/spec/item/validation_spec.rb
+++ b/spec/item/validation_spec.rb
@@ -110,7 +110,6 @@ describe LHS::Item do
   end
 
   context 'pick right endpoint' do
-
     before(:each) do
       class Record < LHS::Record
         endpoint 'http://datastore/v2/records'
@@ -118,7 +117,7 @@ describe LHS::Item do
       end
       stub_request(:get, "http://datastore/v2/records/1")
         .to_return(body: { href: 'http://datastore/v2/records/1' }.to_json)
-       stub_request(:post, "http://datastore/v2/records/1?persist=false")
+      stub_request(:post, "http://datastore/v2/records/1?persist=false")
         .to_return(body: {}.to_json)
     end
 

--- a/spec/item/validation_spec.rb
+++ b/spec/item/validation_spec.rb
@@ -108,4 +108,23 @@ describe LHS::Item do
       end
     end
   end
+
+  context 'pick right endpoint' do
+
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://datastore/v2/records'
+        endpoint 'http://datastore/v2/records/:id', validates: true
+      end
+      stub_request(:get, "http://datastore/v2/records/1")
+        .to_return(body: { href: 'http://datastore/v2/records/1' }.to_json)
+       stub_request(:post, "http://datastore/v2/records/1?persist=false")
+        .to_return(body: {}.to_json)
+    end
+
+    it 'takes the right endpoint for validation' do
+      record = Record.find(1)
+      record.valid?
+    end
+  end
 end


### PR DESCRIPTION
LHS was taking the wrong endpoint when validating in the following case:

```ruby
class Recrod < LHS::Record
  endpoint ':datastore/v2/records'
  endpoint ':datastore/v2/records/:id', validates: 'publish'
end
```

```ruby
record = Record.find(1)
# GET :datastore/v2/records
# { href: 'http://datastore/v2/records/1', name: 'Test' }
record.valid?
```

LHS took `:datastore/v2/records` as endpoint for validation even though the fetched record contained an embeded `href`. The reason it was not taking the correct endpoint was because the fetched record was containing the data for the paramter `id` itself. 

Injecting `{ href: 'http://datastore/v2/records/1', name: 'Test' }` into `:datastore/v2/records/:id` lead to an incomplete endpoint url as the record does not contain `id`.

This special case is fixed now, as parameters from embeded endpoints are extracted and taken into consideration now we stop relying only on the record data itself.
