### PR TITLE
! batch processing with configured pagination

### DIFF
--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -23,9 +23,9 @@ class LHS::Record
         batch_size = options[:batch_size] || LHS::Pagination::DEFAULT_LIMIT
         params = options[:params] || {}
         loop do # as suggested by Matz
-          data = request(params: params.merge(limit: batch_size, offset: start))
-          batch_size = data._raw[:limit]
-          left = data._raw[:total].to_i - data._raw[:offset].to_i - data._raw[:limit].to_i
+          data = request(params: params.merge(limit_key => batch_size, pagination_key => start))
+          batch_size = data._raw[limit_key]
+          left = data._raw[total_key].to_i - data._raw[pagination_key].to_i - data._raw[limit_key].to_i
           yield new(data)
           break if left <= 0
           start += batch_size

--- a/spec/record/find_in_batches_spec.rb
+++ b/spec/record/find_in_batches_spec.rb
@@ -65,7 +65,6 @@ describe LHS::Collection do
   end
 
   context 'configured pagination' do
-
     before(:each) do
       class Record < LHS::Record
         endpoint ':datastore/:campaign_id/feedbacks'
@@ -74,7 +73,7 @@ describe LHS::Collection do
       end
     end
 
-    let(:options) { {items_key: 'docs', limit_key: 'size', pagination_key: 'start', total_key: 'totalResults'} }
+    let(:options) { { items_key: 'docs', limit_key: 'size', pagination_key: 'start', total_key: 'totalResults' } }
 
     it 'capable to do batch processing with configured pagination' do
       stub_request(:get, "#{datastore}/feedbacks?size=230&start=1").to_return(status: 200, body: api_response((1..100).to_a, 1, options))


### PR DESCRIPTION
Bug Fix

LHS was not capable to do batch processing (internal pagination) when configured LHS::Record had custom pagination configuration (like items = 'docs', total = 'totalResults' etc.).

This fixes it and uses configured pagination to be applied when doing batch processing.