### PR TITLE
Forward options to included/referenced resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,16 @@ Favorite.includes(:place).where(user_id: current_user.id)
 # Will include places and applies endpoint options to authenticate the request.
 ```
 
+### Forward options used for request made to include referenced resources
+
+Provide options to the requests made to include referenced resources:
+
+```
+
+  Favorite.includes(:place).references(place: { auth: { bearer: '123' }})
+
+```
+
 ## Map data
 
 To influence how data is accessed/provied, you can use mappings to either map deep nested data or to manipulate data when its accessed. Simply create methods inside the LHS::Record. They can access underlying data:

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ After fetching [single](#find-single-records) or [multiple](#find-multiple-recor
 You can apply options to the request chain. Those options will be forwarded to the request perfomed by the chain/query.
 
 ```ruby
+  # Authenticate with OAuth
   options = { auth: { bearer: '123456' } }
   
   AuthenticatedRecord = Record.options(options)
@@ -365,22 +366,22 @@ After include:
 
 When including linked resources with `includes`, known/defined services and endpoints are used to make those requests.
 That also means that options for endpoints of linked resources are applied when requesting those in addition.
-This allows you to include protected resources (e.g. OAuth) as endpoint options for oauth authentication get applied.
+This allows you to include protected resources (e.g. Basic auth) as endpoint options for oauth authentication get applied.
 
 The [Auth Inteceptor](https://github.com/local-ch/lhc-core-interceptors#auth-interceptor) from [lhc-core-interceptors](https://github.com/local-ch/lhc-core-interceptors) is used to configure the following endpoints.
 
 ```ruby
 class Favorite < LHS::Record
 
-  endpoint ':datastore/:user_id/favorites', auth: { bearer: -> { bearer_token } }
-  endpoint ':datastore/:user_id/favorites/:id', auth: { bearer: -> { bearer_token } }
+  endpoint ':datastore/:user_id/favorites', auth: { basic: { username: 'steve', password: 'can' } }
+  endpoint ':datastore/:user_id/favorites/:id', auth: { basic: { username: 'steve', password: 'can' } }
 
 end
 
 class Place < LHS::Record
 
-  endpoint ':datastore/v2/places', auth: { bearer: -> { bearer_token } }
-  endpoint ':datastore/v2/places/:id', auth: { bearer: -> { bearer_token } }
+  endpoint ':datastore/v2/places', auth: { basic: { username: 'steve', password: 'can' } }
+  endpoint ':datastore/v2/places/:id', auth: { basic: { username: 'steve', password: 'can' } }
 
 end
 

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   s.test_files   = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.requirements << 'Ruby >= 1.9.2'
-  s.required_ruby_version = '>= 1.9.2'
+  s.requirements << 'Ruby >= 2.0.0'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_dependency 'lhc', '>= 3.5.2'
   s.add_dependency 'lhc-core-interceptors', '>= 2.0.1'

--- a/lib/lhs/concerns/record/includes.rb
+++ b/lib/lhs/concerns/record/includes.rb
@@ -5,22 +5,35 @@ class LHS::Record
   module Includes
     extend ActiveSupport::Concern
 
+    included do
+      cattr_accessor :including, :referencing
+    end
+
     module ClassMethods
-      def including
-        @including
-      end
-
-      def including=(including)
-        @including = including
-      end
-
       def includes(*args)
+        class_clone_factory(args).tap do |class_clone|
+          class_clone.including = unfold_args(args)
+        end
+      end
+
+      def references(*args)
+        class_clone_factory(args).tap do |class_clone|
+          class_clone.referencing = unfold_args(args)
+        end
+      end
+
+      private
+
+      def unfold_args(args)
+        args.size == 1 ? args[0] : args
+      end
+
+      def class_clone_factory(args)
         name = "#{self}#{args.object_id}"
         constant = Object.const_set(name.demodulize, self.dup) # rubocop:disable Style/RedundantSelf
         class_clone = constant
         class_clone.endpoints = endpoints
         class_clone.mapping = mapping
-        class_clone.including = args.size == 1 ? args[0] : args
         class_clone
       end
     end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -19,20 +19,20 @@ class LHS::Record
       # Convert URLs in options to endpoint templates
       def convert_options_to_endpoints(options)
         if options.is_a?(Array)
-          options.map { |option| convert_option_to_endpoints(option) }
+          options.map { |options| convert_options_to_endpoint(options) }
         else
-          convert_option_to_endpoints(options)
+          convert_options_to_endpoint(options)
         end
       end
 
-      def convert_option_to_endpoints(option)
-        return unless option.present?
-        new_options = option.dup
-        url = option[:url]
+      def convert_options_to_endpoint(options)
+        return unless options.present?
+        new_options = options.dup
+        url = options[:url]
         endpoint = LHS::Endpoint.for_url(url)
         return unless endpoint
         template = endpoint.url
-        new_options = new_options.merge(params: LHC::Endpoint.values_as_params(template, url))
+        new_options = new_options.deep_merge(params: LHC::Endpoint.values_as_params(template, url))
         new_options[:url] = template
         new_options
       end
@@ -80,17 +80,18 @@ class LHS::Record
         end
       end
 
-      def handle_includes(includes, data)
+      def handle_includes(includes, data, references = {})
+        references ||= {}
         if includes.is_a? Hash
-          includes.each { |included, sub_includes| handle_include(included, data, sub_includes) }
+          includes.each { |included, sub_includes| handle_include(included, data, sub_includes, references[included]) }
         elsif includes.is_a? Array
-          includes.each { |included| handle_includes(included, data) }
+          includes.each { |included| handle_includes(included, data, references) }
         else
-          handle_include(includes, data)
+          handle_include(includes, data, nil, references[includes])
         end
       end
 
-      def handle_include(included, data, sub_includes = nil)
+      def handle_include(included, data, sub_includes = nil, references = nil)
         return if data.blank? || skip_loading_includes?(data, included)
         options =
           if data.collection?
@@ -100,8 +101,20 @@ class LHS::Record
           else
             url_option_for(data, included)
           end
+        options = extend_with_references(options, references)
         addition = load_include(options, data, sub_includes)
         extend_raw_data!(data, addition, included)
+      end
+
+      # Extends request options with options provided for this reference
+      def extend_with_references(options, references)
+        return options unless references
+        options ||= {}
+        if options.is_a?(Array)
+          options.map{ |options| options.merge(references) }
+        else
+          options.merge(references)
+        end
       end
 
       def skip_loading_includes?(data, included)
@@ -140,7 +153,7 @@ class LHS::Record
         data = restore_with_nils(data, locate_nils(options)) # nil objects in data provide location information for mapping
         unless data.empty?
           data = LHS::Data.new(data, nil, self)
-          handle_includes(including, data) if including
+          handle_includes(including, data, referencing) if including
         end
         data
       end
@@ -200,7 +213,7 @@ class LHS::Record
         endpoint = find_endpoint(options[:params])
         response = LHC.request(process_options(options, endpoint))
         data = LHS::Data.new(response.body, nil, self, response.request, endpoint)
-        handle_includes(including, data) if including
+        handle_includes(including, data, referencing) if including
         data
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -84,7 +84,7 @@ class LHS::Record
         if includes.is_a? Hash
           includes.each { |included, sub_includes| handle_include(included, data, sub_includes, references[included]) }
         elsif includes.is_a? Array
-          includes.each { |included| handle_includes(included, data, references) }
+          includes.each { |included| handle_includes(included, data, references[:included]) }
         else
           handle_include(includes, data, nil, references[includes])
         end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -27,12 +27,11 @@ class LHS::Record
 
       def convert_options_to_endpoint(options)
         return unless options.present?
-        new_options = options.dup
         url = options[:url]
         endpoint = LHS::Endpoint.for_url(url)
         return unless endpoint
         template = endpoint.url
-        new_options = new_options.deep_merge(params: LHC::Endpoint.values_as_params(template, url))
+        new_options = options.deep_merge(params: LHC::Endpoint.values_as_params(template, url))
         new_options[:url] = template
         new_options
       end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -19,7 +19,7 @@ class LHS::Record
       # Convert URLs in options to endpoint templates
       def convert_options_to_endpoints(options)
         if options.is_a?(Array)
-          options.map { |options| convert_options_to_endpoint(options) }
+          options.map { |request_options| convert_options_to_endpoint(request_options) }
         else
           convert_options_to_endpoint(options)
         end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -111,7 +111,7 @@ class LHS::Record
         return options unless references
         options ||= {}
         if options.is_a?(Array)
-          options.map{ |options| options.merge(references) }
+          options.map { |request_options| request_options.merge(references) }
         else
           options.merge(references)
         end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -84,7 +84,7 @@ class LHS::Record
         if includes.is_a? Hash
           includes.each { |included, sub_includes| handle_include(included, data, sub_includes, references[included]) }
         elsif includes.is_a? Array
-          includes.each { |included| handle_includes(included, data, references[:included]) }
+          includes.each { |included| handle_includes(included, data, references[included]) }
         else
           handle_include(includes, data, nil, references[includes])
         end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -338,7 +338,6 @@ describe LHS::Record do
   end
 
   context 'includes with options' do
-
     before(:each) do
       class Customer < LHS::Record
         endpoint ':datastore/customers/:id'


### PR DESCRIPTION
In case you want to forward options for the requests beeing made to fetch included/referenced resources:
```
Favorite.includes(:place).references(place: { auth: { bearer: '123' }})
```

Major version increase ahead, because of new ruby > 2.0.0 dependency.