### PR TITLE
Expand included collection items

### DIFF
--- a/lib/lhs/concerns/record/includes.rb
+++ b/lib/lhs/concerns/record/includes.rb
@@ -22,12 +22,6 @@ class LHS::Record
         end
       end
 
-      def includes(*args)
-        class_clone_factory(args).tap do |class_clone|
-          class_clone.including = unfold_args(args)
-        end
-      end
-
       def without_including
         class_clone_factory(rand.to_s.gsub(/\D/, '')).tap do |class_clone|
           class_clone.including = nil

--- a/lib/lhs/concerns/record/includes.rb
+++ b/lib/lhs/concerns/record/includes.rb
@@ -15,12 +15,29 @@ class LHS::Record
       end
 
       def includes(*args)
+        class_clone_factory(args).tap do |class_clone|
+          class_clone.including = unfold_args(args)
+        end
+      end
+
+      def without_including
+        class_clone_factory(rand.to_s.gsub(/\D/, '')).tap do |class_clone|
+          class_clone.including = nil
+        end
+      end
+
+      private
+
+      def unfold_args(args)
+        args.size == 1 ? args[0] : args
+      end
+
+      def class_clone_factory(args)
         name = "#{self}#{args.object_id}"
         constant = Object.const_set(name.demodulize, self.dup) # rubocop:disable Style/RedundantSelf
         class_clone = constant
         class_clone.endpoints = endpoints
         class_clone.mapping = mapping
-        class_clone.including = args.size == 1 ? args[0] : args
         class_clone
       end
     end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -108,7 +108,7 @@ class LHS::Record
       def options_for_data(data, included = nil)
         if data.collection?
           options_for_multiple(data, included)
-        elsif data[included].collection?
+        elsif included && data[included].collection?
           options_for_nested_items(data, included)
         else
           url_option_for(data, included)
@@ -129,6 +129,7 @@ class LHS::Record
       end
 
       def no_expanded_data?(addition)
+        return false if addition.blank?
         if addition.item?
           (addition._raw.keys - [:href]).empty?
         elsif addition.collection?
@@ -197,7 +198,7 @@ class LHS::Record
 
       def options_for_nested_items(data, key = nil)
         data[key].map do |item|
-          url_option_for(item, key)
+          url_option_for(item)
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -75,13 +75,17 @@ class LHS::Record
         if target._raw.is_a? Array
           data[key] = addition.map(&:_raw)
         else # hash with items
-          target._raw[items_key] ||= []
-          if target._raw[items_key].empty?
-            target._raw[items_key] = addition.map(&:_raw)
-          else
-            target._raw[items_key].each_with_index do |item, index|
-              item.merge!(addition[index])
-            end
+          extend_base_item_with_hash_of_items!(target, addition)
+        end
+      end
+
+      def extend_base_item_with_hash_of_items!(target, addition)
+        target._raw[items_key] ||= []
+        if target._raw[items_key].empty?
+          target._raw[items_key] = addition.map(&:_raw)
+        else
+          target._raw[items_key].each_with_index do |item, index|
+            item.merge!(addition[index])
           end
         end
       end
@@ -107,13 +111,9 @@ class LHS::Record
       end
 
       def options_for_data(data, included = nil)
-        if data.collection?
-          options_for_multiple(data, included)
-        elsif included && data[included].collection?
-          options_for_nested_items(data, included)
-        else
-          url_option_for(data, included)
-        end
+        return options_for_multiple(data, included) if data.collection?
+        return options_for_nested_items(data, included) if included && data[included].collection?
+        url_option_for(data, included)
       end
 
       def expand_addition!(data, included)

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -372,6 +372,7 @@ describe LHS::Record do
         endpoint ':datastore/places'
       end
     end
+  end
 
     it 'forwards includes options to requests made for those includes' do
       stub_request(:get, "#{datastore}/customers/1")

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -158,6 +158,7 @@ describe LHS::Record do
       end
 
       it 'uses interceptors for included links from known services' do
+        # rubocop:disable RSpec/InstanceVariable
         stub_feedback_request
         stub_entry_request
 
@@ -166,6 +167,7 @@ describe LHS::Record do
 
         expect(Feedback.includes(:entry).where.first.entry.name).to eq 'Casa Ferlin'
         expect(@called).to eq 2
+        # rubocop:enable RSpec/InstanceVariable
       end
     end
 

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -158,7 +158,6 @@ describe LHS::Record do
       end
 
       it 'uses interceptors for included links from known services' do
-        # rubocop:disable RSpec/InstanceVariable
         stub_feedback_request
         stub_entry_request
 
@@ -167,7 +166,6 @@ describe LHS::Record do
 
         expect(Feedback.includes(:entry).where.first.entry.name).to eq 'Casa Ferlin'
         expect(@called).to eq 2
-        # rubocop:enable RSpec/InstanceVariable
       end
     end
 

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -361,6 +361,8 @@ describe LHS::Record do
       place = Customer.includes(:places).find(1).places.first
       assert_requested(item_request)
       expect(place.name).to eq 'Casa Ferlin'
+    end
+  end
 
   context 'includes with options' do
     before(:each) do
@@ -372,7 +374,6 @@ describe LHS::Record do
         endpoint ':datastore/places'
       end
     end
-  end
 
     it 'forwards includes options to requests made for those includes' do
       stub_request(:get, "#{datastore}/customers/1")


### PR DESCRIPTION
In the following case, LHS was not expanding included resources:

```
Customer.includes(:places).find(1)
GET 'customers/1'
```
```
{
  places: { href: 'customers/1/places' }
}
```
`includes` fetches places
```
GET 'customers/1/places'
{
  items: [
    { href: 'datastore/places/1' },
    { href: 'datastore/places/2' },
    { href: 'datastore/places/3' }
  ]
}
```
but this just includes a list of links, so LHS was not further including the requested resources.

Now it does also fetch all those links in order to fulfil the requested: `Customer.includes(:places).find(1)`

Backwards compatible: Minor