### PR TITLE
Error handling with chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ The example would fetch records with the following parameters: `{color: blue, vi
 
 ## Error handling with chains
 
-One benefit of chains is lazy evaluation. This means they get resolved and when data is accessed. This makes it hard to catch errors with normal `rescue` blocks.
+One benefit of chains is lazy evaluation. This means they get resolved when data is accessed. This makes it hard to catch errors with normal `rescue` blocks.
+
 To simplify error handling with chains, you can also chain error handlers to be resolved, as part of the chain.
 
 In case no matchin error handler is found the error gets re-raised.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In case no matchin error handler is found the error gets re-raised.
 ```ruby
 record = Record.where(color: 'blue')
   .handle(LHC::BadRequest, ->(error){ show_error })
-  .handle(LHC::Unauthorized < LHC::ClientError, ->(error){ authorize })
+  .handle(LHC::Unauthorized, ->(error){ authorize })
 ```
 
 [List of possible error classes](https://github.com/local-ch/lhc/tree/master/lib/lhc/errors)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ records = Record.blue.available(true)
 The example would fetch records with the following parameters: `{color: blue, visible: true}`.
 ```
 
+## Error handling with chains
+
+One benefit of chains is lazy evaluation. This means they get resolved and when data is accessed. This makes it hard to catch errors with normal `rescue` blocks.
+To simplify error handling with chains, you can also chain error handlers to be resolved, as part of the chain.
+
+In case no matchin error handler is found the error gets re-raised.
+
+```ruby
+record = Record.where(color: 'blue')
+  .handle(LHC::BadRequest, ->(error){ show_error })
+  .handle(LHC::Unauthorized < LHC::ClientError, ->(error){ authorize })
+```
+
+[List of possible error classes](https://github.com/local-ch/lhc/tree/master/lib/lhc/errors)
+
 ## Find single records
 
 `find` finds a unique record by uniqe identifier (usualy id).

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -256,7 +256,7 @@ class LHS::Record
       end
 
       def handle_error(error, error_handling)
-        error_handlers = error_handling.select { |error_handler| error.is_a? error_handler.class }
+        error_handlers = (error_handling || []).select { |error_handler| error.is_a? error_handler.class }
         if error_handlers.any?
           error_handlers.each { |handler| handler.call(error) }
         else

--- a/spec/record/chain_error_handling_spec.rb
+++ b/spec/record/chain_error_handling_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://local.ch/v2/records'
+    end
+    stub_request(:get, "http://local.ch/v2/records?color=blue")
+      .to_return(status: 400)
+  end
+
+  it 'allows to chain error handling' do
+    # rubocop:disable RSpec/InstanceVariable
+    @errorResolved = false
+    @rescued = false
+    begin
+      record = Record.where(color: 'blue').handle(LHC::Error, ->(error){ @errorResolved = true })
+    rescue => e
+      @rescued = true
+    end
+    record.first
+    expect(@errorResolved).to eq true
+    expect(@rescued).to eq false
+    # rubocop:enable RSpec/InstanceVariable
+  end
+
+  it 'reraises in case chained error is not matched' do
+    # rubocop:disable RSpec/InstanceVariable
+    @errorResolved = false
+    @rescued = false
+    record = Record.where(color: 'blue').handle(LHC::Conflict, ->(error){ @errorResolved = true })
+    begin
+      record.first
+    rescue => _e
+      @rescued = true
+    end
+    expect(@errorResolved).to eq false
+    expect(@rescued).to eq true
+    # rubocop:enable RSpec/InstanceVariable
+  end
+end

--- a/spec/record/chain_error_handling_spec.rb
+++ b/spec/record/chain_error_handling_spec.rb
@@ -11,31 +11,48 @@ describe LHS::Record do
 
   it 'allows to chain error handling' do
     # rubocop:disable RSpec/InstanceVariable
-    @errorResolved = false
+    @error_resolved = false
     @rescued = false
     begin
-      record = Record.where(color: 'blue').handle(LHC::Error, ->(error){ @errorResolved = true })
+      record = Record.where(color: 'blue').handle(LHC::Error, ->(error){ @error_resolved = true })
     rescue => e
       @rescued = true
     end
     record.first
-    expect(@errorResolved).to eq true
+    expect(@error_resolved).to eq true
     expect(@rescued).to eq false
     # rubocop:enable RSpec/InstanceVariable
   end
 
   it 'reraises in case chained error is not matched' do
     # rubocop:disable RSpec/InstanceVariable
-    @errorResolved = false
+    @error_resolved = false
     @rescued = false
-    record = Record.where(color: 'blue').handle(LHC::Conflict, ->(error){ @errorResolved = true })
+    record = Record.where(color: 'blue').handle(LHC::Conflict, ->(error){ @error_resolved = true })
     begin
       record.first
     rescue => _e
       @rescued = true
     end
-    expect(@errorResolved).to eq false
+    expect(@error_resolved).to eq false
     expect(@rescued).to eq true
+    # rubocop:enable RSpec/InstanceVariable
+  end
+
+  it 'calls all the handlers' do
+    # rubocop:disable RSpec/InstanceVariable
+    @error_resolved = 0
+    @rescued = false
+    begin
+      record = Record.where(color: 'blue')
+        .handle(LHC::Error, ->(error){ @error_resolved += 1 })
+        .handle(LHC::Error, ->(error){ @error_resolved += 2 })
+    rescue => e
+      @rescued = true
+    end
+    record.first
+    expect(@error_resolved).to eq 3
+    expect(@rescued).to eq false
     # rubocop:enable RSpec/InstanceVariable
   end
 end

--- a/spec/record/chain_error_handling_spec.rb
+++ b/spec/record/chain_error_handling_spec.rb
@@ -14,8 +14,8 @@ describe LHS::Record do
     @error_resolved = false
     @rescued = false
     begin
-      record = Record.where(color: 'blue').handle(LHC::Error, ->(error){ @error_resolved = true })
-    rescue => e
+      record = Record.where(color: 'blue').handle(LHC::Error, ->(_error) { @error_resolved = true })
+    rescue => _e
       @rescued = true
     end
     record.first
@@ -28,7 +28,7 @@ describe LHS::Record do
     # rubocop:disable RSpec/InstanceVariable
     @error_resolved = false
     @rescued = false
-    record = Record.where(color: 'blue').handle(LHC::Conflict, ->(error){ @error_resolved = true })
+    record = Record.where(color: 'blue').handle(LHC::Conflict, ->(_error) { @error_resolved = true })
     begin
       record.first
     rescue => _e
@@ -45,9 +45,9 @@ describe LHS::Record do
     @rescued = false
     begin
       record = Record.where(color: 'blue')
-        .handle(LHC::Error, ->(error){ @error_resolved += 1 })
-        .handle(LHC::Error, ->(error){ @error_resolved += 2 })
-    rescue => e
+        .handle(LHC::Error, ->(_error) { @error_resolved += 1 })
+        .handle(LHC::Error, ->(_error) { @error_resolved += 2 })
+    rescue => _e
       @rescued = true
     end
     record.first

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -149,25 +149,20 @@ describe LHS::Record do
           }.to_json)
       end
 
+      let(:interceptor) { spy('interceptor') }
+
       before(:each) do
         class Entry < LHS::Record
           endpoint ':datastore/local-entries/:id'
         end
-        class SomeInterceptor < LHC::Interceptor; end
-        LHC.config.interceptors = [SomeInterceptor]
+        LHC.config.interceptors = [interceptor]
       end
 
       it 'uses interceptors for included links from known services' do
-        # rubocop:disable RSpec/InstanceVariable
         stub_feedback_request
         stub_entry_request
-
-        @called = 0
-        allow_any_instance_of(SomeInterceptor).to receive(:before_request) { @called += 1 }
-
         expect(Feedback.includes(:entry).where.first.entry.name).to eq 'Casa Ferlin'
-        expect(@called).to eq 2
-        # rubocop:enable RSpec/InstanceVariable
+        expect(interceptor).to have_received(:before_request).twice
       end
     end
 


### PR DESCRIPTION
## Error handling with chains

One benefit of chains is lazy evaluation. This means they get resolved when data is accessed. This makes it hard to catch errors with normal `rescue` blocks.

To simplify error handling with chains, you can also chain error handlers to be resolved, as part of the chain.

In case no matchin error handler is found the error gets re-raised.

```ruby
record = Record.where(color: 'blue')
  .handle(LHC::BadRequest, ->(error){ show_error })
  .handle(LHC::Unauthorized, ->(error){ authorize })
```

[List of possible error classes](https://github.com/local-ch/lhc/tree/master/lib/lhc/errors)