### PR TITLE
Do not store values set by custom setters in _raw by default

### DIFF
--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -25,7 +25,7 @@ class LHS::Record
     data = LHS::Data.new({}, nil, self.class) unless data
     data = LHS::Data.new(data, nil, self.class) unless data.is_a?(LHS::Data)
     define_singleton_method(:_data) { data }
-    consider_custom_setters!
+    apply_custom_setters!
   end
 
   def as_json(options = nil)
@@ -48,23 +48,13 @@ class LHS::Record
 
   private
 
-  def consider_custom_setters!
-    data = instance_data
-
-    return if !data.is_a?(Hash)
-
-    custom_setters = data.keys.find_all { |k| public_methods.include?("#{k}=".to_sym) }
+  def apply_custom_setters!
+    return if !_data.item? || !_data._raw.respond_to?(:keys)
+    raw = _data._raw
+    custom_setters = raw.keys.find_all { |key| public_methods.include?("#{key}=".to_sym) }
     custom_setters.each do |setter|
-      value = data.delete(setter)
+      value = raw.delete(setter)
       send("#{setter}=", value)
-    end
-  end
-
-  def instance_data
-    if _data._proxy.is_a?(LHS::Collection) && _data._raw.is_a?(Hash)
-      _data._raw.fetch(items_key, [])
-    else
-      _data._raw
     end
   end
 end

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -59,7 +59,7 @@ class LHS::Record
 
   def instance_data
     if _data._proxy.is_a?(LHS::Collection) && _data._raw.is_a?(Hash)
-      _data._raw.fetch(:items, [])
+      _data._raw.fetch(items_key, [])
     else
       _data._raw
     end

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -25,7 +25,7 @@ class LHS::Record
     data = LHS::Data.new({}, nil, self.class) unless data
     data = LHS::Data.new(data, nil, self.class) unless data.is_a?(LHS::Data)
     define_singleton_method(:_data) { data }
-    consider_custom_setters
+    consider_custom_setters!
   end
 
   def as_json(options = nil)
@@ -48,12 +48,15 @@ class LHS::Record
 
   private
 
-  def consider_custom_setters
-    return if !instance_data.is_a?(Hash)
-    instance_data.each do |k, v|
-      if public_methods.include?("#{k}=".to_sym)
-        send("#{k}=", v)
-      end
+  def consider_custom_setters!
+    data = instance_data
+
+    return if !data.is_a?(Hash)
+
+    custom_setters = data.keys.find_all { |k| public_methods.include?("#{k}=".to_sym) }
+    custom_setters.each do |setter|
+      value = data.delete(setter)
+      send("#{setter}=", value)
     end
   end
 

--- a/spec/record/create_spec.rb
+++ b/spec/record/create_spec.rb
@@ -73,7 +73,7 @@ describe LHS::Record do
           .to_return(status: 400, body: creation_error.to_json)
         expect(lambda {
           Feedback.create!(object.merge(campaign_id: '12345'))
-        }).to raise_error
+        }).to raise_error(LHC::Error)
       end
     end
 

--- a/spec/record/endpoint_misconfiguration_spec.rb
+++ b/spec/record/endpoint_misconfiguration_spec.rb
@@ -10,7 +10,8 @@ describe LHS::Record do
             endpoint ':datastore/v2/reviews'
           end
         }
-      ).to raise_error
+      ).to raise_error(/Clashing endpoints/)
+
       expect(
         lambda {
           class Record < LHS::Record
@@ -18,7 +19,7 @@ describe LHS::Record do
             endpoint ':datastore/v2/:campaign_id/reviews'
           end
         }
-      ).to raise_error
+      ).to raise_error(/Clashing endpoints/)
     end
   end
 end

--- a/spec/record/inspect_spec.rb
+++ b/spec/record/inspect_spec.rb
@@ -6,21 +6,41 @@ describe LHS::Record do
       endpoint 'http://datastore/records/:id'
     end
     stub_request(:get, "http://datastore/records/1")
-      .to_return(body: {
-        name: 'Steve',
-        kind: {
-          animal: {
-            type: 'Monkey'
-          }
-        }
-      }.to_json)
+      .to_return(body: attrbitutes.to_json)
   end
 
   let(:record) { Record.find(1) }
+  let(:attrbitutes) do
+    {
+      name: 'Steve',
+      kind: {
+        animal: {
+          type: 'Monkey'
+        }
+      }
+    }
+  end
+
+  let(:output) { "Record##{record.object_id}\n:name => \"Steve\"\n:kind => {:animal=>{:type=>\"Monkey\"}}" }
 
   context 'inspect' do
     it 'prints the record on the terminal: each attrbitute on a new line' do
-      expect(record.inspect).to eq "Record##{record.object_id}\n:name => \"Steve\"\n:kind => {:animal=>{:type=>\"Monkey\"}}"
+      expect(record.inspect).to eq(output)
+    end
+
+
+    context 'with custom setters that do no touch raw data' do
+      before do
+        class Record
+          attr_accessor :listing
+        end
+      end
+
+      let(:record) { Record.new(attrbitutes.merge(listing: double('listing'))) }
+
+      it 'does not print what is not in raw' do
+        expect(record.inspect).to eq(output)
+      end
     end
   end
 end

--- a/spec/record/inspect_spec.rb
+++ b/spec/record/inspect_spec.rb
@@ -28,7 +28,6 @@ describe LHS::Record do
       expect(record.inspect).to eq(output)
     end
 
-
     context 'with custom setters that do no touch raw data' do
       before do
         class Record

--- a/spec/record/new_spec.rb
+++ b/spec/record/new_spec.rb
@@ -65,6 +65,26 @@ describe LHS::Record do
         expect(feedback.ratings.first.name).to eq :z
       end
 
+      context 'that do not affect raw data' do
+        before(:each) do
+          class Rating
+            attr_accessor :listing
+          end
+        end
+
+        let(:listing) { double('listing') }
+
+        it 'are used by initializer' do
+          feedback = Rating.new(listing: listing)
+          expect(feedback.listing).to eq(listing)
+        end
+
+        it 'do not set raw data' do
+          feedback = Rating.new(listing: listing)
+          expect(feedback._raw[:listing]).to be_nil
+        end
+      end
+
       context 'and custom getters' do
         before(:each) do
           class Rating


### PR DESCRIPTION
Consider following use case:

```ruby
class Feedback < LHS::Record
  attr_accessor :listing
end

listing = Local::Listing(...)
f1 = Feedback.new(listing: listing)

f1._raw
  => { listing: listing }

f2 = Feedback.new.tap do |f|
  f.listing = listing
end

f2._raw
  => {}
```

This PR fixes this issue.

The reason it occurred was that we had an assumption that everything that has a custom setter will end up in the raw data anyway, which is not always true (think instance variables).

It wouldn't be a big of an issue if not for the recursive data structures, which then cause stack overflow when trying to send them.