### PR TITLE
Find in parallel + Handle Errors (chained)

### DIFF
--- a/.rubocop.localch.yml
+++ b/.rubocop.localch.yml
@@ -19,10 +19,7 @@ AllCops:
 
 Rails:
   Enabled: true
-
-require:
-  - rubocop-rspec
-
+  
 Lint/HandleExceptions:
   Exclude:
     - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,3 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
-
-gem 'lhc', path: '../lhc'

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,5 @@ gemspec
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
+
+gem 'lhc', path: '../lhc'

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If no record is found, `nil` is returned.
 In case you want to fetch multiple records by id in parallel, you can also do this with `find`:
 
 ```ruby
-Record.find([1,2,3])
+Record.find(1,2,3)
 ```
 
 If you want to inject values for the failing records, that might not have been found, you can inject values for them with error handlers:
@@ -186,7 +186,7 @@ If you want to inject values for the failing records, that might not have been f
 ```ruby
 data = Record
   .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
-  .find([1, 2, 3])
+  .find(1, 2, 3)
 data[1].name # 'unknown'
 ```
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ If no record is found, `nil` is returned.
 
 `first!` raises LHC::NotFound if nothing was found.
 
+# Find multiple single records in parallel
+
+In case you want to fetch multiple records by id in parallel, you can also do this with `find`:
+
+```ruby
+Record.find([1,2,3])
+```
+
+If you want to inject values for the failing records, that might not have been found, you can inject values for them with error handlers:
+
+```ruby
+data = Record
+  .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
+  .find([1, 2, 3])
+data[1].name # 'unknown'
+```
+
 ## Navigate data
 
 After fetching [single](#find-single-records) or [multiple](#find-multiple-records) records you can navigate the received data with ease.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ If no record is found, `nil` is returned.
 In case you want to fetch multiple records by id in parallel, you can also do this with `find`:
 
 ```ruby
-Record.find(1,2,3)
+Record.find(1, 2, 3)
 ```
 
 If you want to inject values for the failing records, that might not have been found, you can inject values for them with error handlers:

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.0.0'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'lhc', '>= 3.5.2'
+  s.add_dependency 'lhc', '>= 3.6.0'
   s.add_dependency 'lhc-core-interceptors', '>= 2.0.1'
 
   s.add_development_dependency 'rspec-rails', '>= 3.0.0'

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -162,7 +162,10 @@ class LHS::Record
       end
 
       def find(args)
-        @record_class.find(args, chain_options)
+        @record_class.find(
+          args,
+          chain_options.merge(error_handler: chain_error_handler)
+        )
       end
 
       def find_by(params = {})
@@ -202,7 +205,7 @@ class LHS::Record
           @record_class.request(
             chain_options
               .merge(params: chain_parameters.merge(chain_pagination))
-              .merge(error_handling: chain_error_handling)
+              .merge(error_handler: chain_error_handler)
           )
         )
       end
@@ -223,7 +226,7 @@ class LHS::Record
         merge_links _links.select { |link| link.is_a? Option }
       end
 
-      def chain_error_handling
+      def chain_error_handler
         _links.select { |link| link.is_a? ErrorHandling }
       end
 

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -161,11 +161,10 @@ class LHS::Record
         push ErrorHandling.new(error_class => handler)
       end
 
-      def find(args)
-        @record_class.find(
-          args,
-          chain_options.merge(error_handler: chain_error_handler)
-        )
+      def find(*args)
+        options = chain_options
+        options = options.merge(error_handler: chain_error_handler) if chain_error_handler.any?
+        @record_class.find(*args.push(options))
       end
 
       def find_by(params = {})
@@ -201,12 +200,11 @@ class LHS::Record
       end
 
       def resolve
+        options = chain_options
+        options = options.merge(params: chain_parameters.merge(chain_pagination))
+        options = options.merge(error_handler: chain_error_handler) if chain_error_handler.any?
         @resolved ||= @record_class.new(
-          @record_class.request(
-            chain_options
-              .merge(params: chain_parameters.merge(chain_pagination))
-              .merge(error_handler: chain_error_handler)
-          )
+          @record_class.request(options)
         )
       end
 

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -29,8 +29,8 @@ class LHS::Record
         elsif args.length == 2 && args.last.is_a?(Hash)
           options = args.pop if args.last.is_a?(Hash)
           args = args.first
-        else
-          options = args.pop if args.last.is_a?(Hash)
+        elsif args.last.is_a?(Hash)
+          options = args.pop
         end
         options ||= nil
         [args, options]
@@ -38,8 +38,8 @@ class LHS::Record
 
       def get_unique_item!(data)
         if data._proxy.is_a?(LHS::Collection)
-          fail LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
-          data.first || fail(LHC::NotFound.new('No item was found.', data._request.response))
+          raise LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
+          data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))
         else
           data
         end

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -38,8 +38,8 @@ class LHS::Record
 
       def get_unique_item!(data)
         if data._proxy.is_a?(LHS::Collection)
-          raise LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
-          data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))
+          fail LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
+          data.first || fail(LHC::NotFound.new('No item was found.', data._request.response))
         else
           data
         end

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -25,7 +25,10 @@ class LHS::Record
 
       def process_args(args)
         if args.length == 1
-          args = args.first 
+          args = args.first
+        elsif args.length == 2 && args.last.is_a?(Hash)
+          options = args.pop if args.last.is_a?(Hash)
+          args = args.first
         else
           options = args.pop if args.last.is_a?(Hash)
         end
@@ -37,6 +40,8 @@ class LHS::Record
         if data._proxy.is_a?(LHS::Collection)
           fail LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
           data.first || fail(LHC::NotFound.new('No item was found.', data._request.response))
+        else
+          data
         end
       end
 

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -7,7 +7,8 @@ class LHS::Record
 
     module ClassMethods
       # Find a single uniqe record
-      def find(args, options = nil)
+      def find(*args)
+        args, options = process_args(args)
         data =
           if args.is_a? Array
             find_in_parallel(args, options)
@@ -21,6 +22,16 @@ class LHS::Record
       end
 
       private
+
+      def process_args(args)
+        if args.length == 1
+          args = args.first 
+        else
+          options = args.pop if args.last.is_a?(Hash)
+        end
+        options ||= nil
+        [args, options]
+      end
 
       def get_unique_item!(data)
         if data._proxy.is_a?(LHS::Collection)

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -9,31 +9,46 @@ class LHS::Record
       # Find a single uniqe record
       def find(args, options = nil)
         data =
-          if args.is_a? Hash
+          if args.is_a? Array
+            find_in_parallel(args, options)
+          elsif args.is_a? Hash
             find_with_parameters(args, options)
           else
             find_by_id(args, options)
           end
-        return data unless data._record
+        return data if data.is_a?(Array) || !data._record
         data._record.new(data)
       end
 
       private
 
-      def find_with_parameters(params, options = {})
-        options ||= {}
-        data = request(options.merge(params: params))
+      def get_unique_item!(data)
         if data._proxy.is_a?(LHS::Collection)
           fail LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
           data.first || fail(LHC::NotFound.new('No item was found.', data._request.response))
-        else
-          data
         end
       end
 
-      def find_by_id(id, options = {})
-        options ||= {}
-        request(options.merge(params: { id: id }))
+      def find_with_parameters(args, options = {})
+        data = request(request_options(args, options))
+        get_unique_item!(data)
+      end
+
+      def find_by_id(args, options = {})
+        request(request_options(args, options))
+      end
+
+      def find_in_parallel(args, options)
+        options = args.map { |argument| request_options(argument, options) }
+        request(options)
+      end
+
+      def request_options(args, options)
+        if args.is_a? Hash
+          (options || {}).merge(params: args)
+        else
+          (options || {}).merge(params: { id: args })
+        end
       end
     end
   end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -233,7 +233,7 @@ class LHS::Record
           return_data = nil
           error_class = LHC::Error.find(response)
           error = error_class.new(error_class, response)
-          handlers = (handlers || []).select { |error_handler| error.is_a? error_handler.class }
+          handlers = handlers.to_a.select { |error_handler| error.is_a? error_handler.class }
           fail(error) unless handlers.any? 
           handlers.each do |handler|
             handlers_return = handler.call(response)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -182,7 +182,10 @@ class LHS::Record
           next unless option.present?
           process_options(option, find_endpoint(option[:params]))
         end
-        data = LHC.request(options.compact).map { |response| LHS::Data.new(response.body, nil, self, response.request) }
+        data = LHC.request(options.compact).map do |response|
+          data = response.body_replacement || response.body
+          LHS::Data.new(data, nil, self, response.request) 
+        end
         data = restore_with_nils(data, locate_nils(options)) # nil objects in data provide location information for mapping
         handle_includes(including, data, referencing) if including && !data.empty?
         data
@@ -231,6 +234,7 @@ class LHS::Record
             handlers_return = handler.call(response)
             return_data = handlers_return if handlers_return.present?
           end
+          return return_data
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -183,8 +183,7 @@ class LHS::Record
           process_options(option, find_endpoint(option[:params]))
         end
         data = LHC.request(options.compact).map do |response|
-          data = response.body_replacement || response.body
-          LHS::Data.new(data, nil, self, response.request) 
+          LHS::Data.new(response.body, nil, self, response.request) 
         end
         data = restore_with_nils(data, locate_nils(options)) # nil objects in data provide location information for mapping
         handle_includes(including, data, referencing) if including && !data.empty?

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -234,7 +234,7 @@ class LHS::Record
           error_class = LHC::Error.find(response)
           error = error_class.new(error_class, response)
           handlers = handlers.to_a.select { |error_handler| error.is_a? error_handler.class }
-          fail(error) unless handlers.any? 
+          fail(error) unless handlers.any?
           handlers.each do |handler|
             handlers_return = handler.call(response)
             return_data = handlers_return if handlers_return.present?

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -183,7 +183,7 @@ class LHS::Record
           process_options(option, find_endpoint(option[:params]))
         end
         data = LHC.request(options.compact).map do |response|
-          LHS::Data.new(response.body, nil, self, response.request) 
+          LHS::Data.new(response.body, nil, self, response.request)
         end
         data = restore_with_nils(data, locate_nils(options)) # nil objects in data provide location information for mapping
         data = LHS::Data.new(data, nil, self)

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -27,7 +27,7 @@ class LHS::Item < LHS::Proxy
     name = args.first if name == :[]
     value = _data._raw[name.to_s]
     if value.nil? && _data._raw.present?
-      value = _data._raw[name.to_sym] 
+      value = _data._raw[name.to_sym]
       value ||= _data._raw[name.to_s.classify.to_sym]
     end
     if value.is_a?(Hash)

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -26,8 +26,10 @@ class LHS::Item < LHS::Proxy
     return set(name, args.try(&:first)) if name.to_s[/=$/]
     name = args.first if name == :[]
     value = _data._raw[name.to_s]
-    value = _data._raw[name.to_sym] if value.nil?
-    value = _data._raw[name.to_s.classify.to_sym] if value.nil?
+    if value.nil? && _data._raw.present?
+      value = _data._raw[name.to_sym] 
+      value ||= _data._raw[name.to_s.classify.to_sym]
+    end
     if value.is_a?(Hash)
       handle_hash(value)
     elsif value.is_a?(Array)

--- a/spec/record/find_in_parallel_spec.rb
+++ b/spec/record/find_in_parallel_spec.rb
@@ -9,12 +9,12 @@ describe LHS::Record do
 
   context 'find in parallel' do
     before(:each) do
-      stub_request(:get, "http://datastore/records/1").to_return(status: 200, body: {id: 1}.to_json)
-      stub_request(:get, "http://datastore/records/3").to_return(status: 200, body: {id: 3}.to_json)
+      stub_request(:get, "http://datastore/records/1").to_return(status: 200, body: { id: 1 }.to_json)
+      stub_request(:get, "http://datastore/records/3").to_return(status: 200, body: { id: 3 }.to_json)
     end
 
     it 'finds records in parallel' do
-      stub_request(:get, "http://datastore/records/2").to_return(status: 200, body: {id: 2}.to_json)
+      stub_request(:get, "http://datastore/records/2").to_return(status: 200, body: { id: 2 }.to_json)
       allow(Record).to receive(:request).and_call_original
       data = Record.find([1, 2, 3])
       expect(Record).to have_received(:request).once
@@ -31,7 +31,7 @@ describe LHS::Record do
     it 'applies error handlers from the chain and returns whatever the error handler returns' do
       stub_request(:get, "http://datastore/records/2").to_return(status: 401)
       data = Record
-        .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
+        .handle(LHC::Unauthorized, ->(_response) { Record.new(name: 'unknown') })
         .find(1, 2, 3)
       expect(data[1].name).to eq 'unknown'
     end

--- a/spec/record/find_in_parallel_spec.rb
+++ b/spec/record/find_in_parallel_spec.rb
@@ -32,7 +32,7 @@ describe LHS::Record do
       stub_request(:get, "http://datastore/records/2").to_return(status: 401)
       data = Record
         .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
-        .find([1, 2, 3])
+        .find(1, 2, 3)
       expect(data[1].name).to eq 'unknown'
     end
   end

--- a/spec/record/find_in_parallel_spec.rb
+++ b/spec/record/find_in_parallel_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://datastore/records/:id'
+    end
+  end
+
+  context 'find in parallel' do
+    before(:each) do
+      stub_request(:get, "http://datastore/records/1").to_return(status: 200, body: {id: 1}.to_json)
+      stub_request(:get, "http://datastore/records/2").to_return(status: 200, body: {id: 2}.to_json)
+    end
+
+    it 'finds records in parallel' do
+      stub_request(:get, "http://datastore/records/3").to_return(status: 200, body: {id: 3}.to_json)
+      allow(Record).to receive(:request).and_call_original
+      data = Record.find([1, 2, 3])
+      expect(Record).to have_received(:request).once
+      expect(data[0].id).to eq 1
+      expect(data[1].id).to eq 2
+      expect(data[2].id).to eq 3
+    end
+
+    it 'raises an exeption if one of the parallel request fails' do
+      stub_request(:get, "http://datastore/records/3").to_return(status: 401)
+      expect(-> { Record.find([1, 2, 3]) }).to raise_error(LHC::Unauthorized)
+    end
+
+    it 'applies error handlers from the chain and returns whatever the error handler returns' do
+      stub_request(:get, "http://datastore/records/3").to_return(status: 401)
+      data = Record
+        .handle(LHC::Unauthorized, ->(response) { Record.new })
+        .find([1, 2, 3])
+      binding.pry
+    end
+  end
+end

--- a/spec/record/find_in_parallel_spec.rb
+++ b/spec/record/find_in_parallel_spec.rb
@@ -10,11 +10,11 @@ describe LHS::Record do
   context 'find in parallel' do
     before(:each) do
       stub_request(:get, "http://datastore/records/1").to_return(status: 200, body: {id: 1}.to_json)
-      stub_request(:get, "http://datastore/records/2").to_return(status: 200, body: {id: 2}.to_json)
+      stub_request(:get, "http://datastore/records/3").to_return(status: 200, body: {id: 3}.to_json)
     end
 
     it 'finds records in parallel' do
-      stub_request(:get, "http://datastore/records/3").to_return(status: 200, body: {id: 3}.to_json)
+      stub_request(:get, "http://datastore/records/2").to_return(status: 200, body: {id: 2}.to_json)
       allow(Record).to receive(:request).and_call_original
       data = Record.find([1, 2, 3])
       expect(Record).to have_received(:request).once
@@ -24,16 +24,16 @@ describe LHS::Record do
     end
 
     it 'raises an exeption if one of the parallel request fails' do
-      stub_request(:get, "http://datastore/records/3").to_return(status: 401)
+      stub_request(:get, "http://datastore/records/2").to_return(status: 401)
       expect(-> { Record.find([1, 2, 3]) }).to raise_error(LHC::Unauthorized)
     end
 
     it 'applies error handlers from the chain and returns whatever the error handler returns' do
-      stub_request(:get, "http://datastore/records/3").to_return(status: 401)
+      stub_request(:get, "http://datastore/records/2").to_return(status: 401)
       data = Record
-        .handle(LHC::Unauthorized, ->(response) { Record.new })
+        .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
         .find([1, 2, 3])
-      binding.pry
+      expect(data[1].name).to eq 'unknown'
     end
   end
 end


### PR DESCRIPTION
# Find multiple single records in parallel

In case you want to fetch multiple records by id in parallel, you can also do this with `find`:

```ruby
Record.find(1, 2, 3)
```

If you want to inject values for the failing records, that might not have been found, you can inject values for them with error handlers:

```ruby
data = Record
  .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
  .find(1, 2, 3)
data[1].name # 'unknown'
```