### PR TITLE
Fixes getters for false values

### DIFF
--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -7,7 +7,6 @@ class LHS::Item < LHS::Proxy
   include Destroy
   include Save
   include Update
-  include Validation
 
   delegate :present?, :blank?, :empty?, to: :_raw
 
@@ -33,7 +32,7 @@ class LHS::Item < LHS::Proxy
     value = _data._raw[name.to_s]
     if value.nil? && _data._raw.present?
       value = _data._raw[name.to_sym]
-      value ||= _data._raw[name.to_s.classify.to_sym]
+      value = _data._raw[name.to_s.classify.to_sym] if value.nil?
     end
     if value.is_a?(Hash)
       handle_hash(value)

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -7,6 +7,7 @@ class LHS::Item < LHS::Proxy
   include Destroy
   include Save
   include Update
+  include Validation
 
   delegate :present?, :blank?, :empty?, to: :_raw
 

--- a/spec/collection/delegate_spec.rb
+++ b/spec/collection/delegate_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 describe LHS::Collection do
-  let(:data) {
+  let(:data) do
     ['ROLE_USER', 'ROLE_LOCALCH_ACCOUNT']
-  }
+  end
 
-  let(:collection){
+  let(:collection) do
     LHS::Collection.new(LHS::Data.new(data))
-  }
+  end
 
   context 'delegates methods to raw' do
     %w(present? blank? empty?).each do |method|

--- a/spec/collection/enumerable_spec.rb
+++ b/spec/collection/enumerable_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 describe LHS::Collection do
-  let(:data) {
+  let(:data) do
     [1, 2, 3]
-  }
+  end
 
-  let(:collection){
+  let(:collection) do
     LHS::Collection.new(LHS::Data.new(data))
-  }
+  end
 
   context 'enumerable' do
     it 'works with map' do

--- a/spec/collection/respond_to_spec.rb
+++ b/spec/collection/respond_to_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 describe LHS::Collection do
-  let(:data) {
+  let(:data) do
     ['ROLE_USER', 'ROLE_LOCALCH_ACCOUNT']
-  }
+  end
 
-  let(:collection){
+  let(:collection) do
     LHS::Data.new(LHS::Data.new(data))
-  }
+  end
 
   context '#respond_to?' do
     # In this case raw collection is an Array implementing first

--- a/spec/data/collection_spec.rb
+++ b/spec/data/collection_spec.rb
@@ -17,13 +17,13 @@ describe LHS::Data do
 
   context 'collections' do
     it 'forwards calls to the collection' do
-      expect(data.count).to be_kind_of Fixnum
+      expect(data.count).to be_kind_of Integer
       expect(data[0]).to be_kind_of LHS::Data
       expect(data.sample).to be_kind_of LHS::Data
     end
 
     it 'provides a total method to get the number of total records' do
-      expect(data.total).to be_kind_of Fixnum
+      expect(data.total).to be_kind_of Integer
     end
   end
 

--- a/spec/item/respond_to_spec.rb
+++ b/spec/item/respond_to_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 describe LHS::Item do
-  let(:item){
+  let(:item) do
     LHS::Item.new(id: 1234)
-  }
+  end
 
   context '#respond_to?' do
     it 'is true for setters' do

--- a/spec/item/setter_spec.rb
+++ b/spec/item/setter_spec.rb
@@ -32,5 +32,11 @@ describe LHS::Item do
       expect((item.name = nil)).to eq nil
       expect(item.name).to eq nil
     end
+
+    it 'sets things to false' do
+      item.recommended = true
+      expect((item.recommended = false)).to eq false
+      expect(item.recommended).to eq false
+    end
   end
 end


### PR DESCRIPTION
PATCH

# Current behaviour
```ruby
item.recommended = false
item.recommended # nil
```

# Expected behaviour
```ruby
item.recommended = false
item.recommended # false
```