### PR TITLE
Destroy records

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,18 @@ You can delete records remotely by calling `destroy` on an LHS::Record.
   record.destroy
 ```
 
+You can also destroy records directly without fetching them first:
+
+```ruby
+  destroyed_record = Record.destroy('1z-5r1fkaj')
+```
+
+or with parameters:
+
+```ruby
+  destroyed_records = Record.destroy(name: 'Steve')
+```
+
 ## Validation
 
 In order to validate LHS::Records before persisting them, you can use the `valid?` (`validate` alias) method.

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -118,8 +118,11 @@ class LHS::Record
       def destroy(options = nil)
         options ||= {}
         options = options.respond_to?(:to_h) ? options : { id: options }
-        @record.destroy(chain_options.merge(options)) if @record
-        @record_class.destroy(options, chain_options)
+        if @record
+          @record.destroy(chain_options.merge(options))
+        else
+          @record_class.destroy(options, chain_options)
+        end
       end
 
       def update(data = {}, options = nil)

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -117,7 +117,9 @@ class LHS::Record
 
       def destroy(options = nil)
         options ||= {}
-        @record.destroy(chain_options.merge(options))
+        options = options.respond_to?(:to_h) ? options : { id: options }
+        @record.destroy(chain_options.merge(options)) if @record
+        @record_class.destroy(options, chain_options)
       end
 
       def update(data = {}, options = nil)

--- a/lib/lhs/concerns/record/destroy.rb
+++ b/lib/lhs/concerns/record/destroy.rb
@@ -1,0 +1,16 @@
+require 'active_support'
+
+class LHS::Record
+
+  module Destroy
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def destroy(args, options = nil)
+        options = {} if options.blank?
+        params = args.respond_to?(:to_h) ? args : { id: args }
+        request(options.merge(params: params, method: :delete))
+      end
+    end
+  end
+end

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -6,8 +6,9 @@ class LHS::Record
   include Chainable
   include Configuration
   include Create
-  include Equality
+  include Destroy
   include Endpoints
+  include Equality
   include Find
   include FindBy
   include First

--- a/spec/record/destroy_spec.rb
+++ b/spec/record/destroy_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 describe LHS::Record do
   context 'destroy' do
-
     before(:each) do
       class Record < LHS::Record
         endpoint 'http://datastore/history'

--- a/spec/record/destroy_spec.rb
+++ b/spec/record/destroy_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'destroy' do
+
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://datastore/history'
+        endpoint 'http://datastore/history/:id'
+      end
+    end
+
+    let(:entry) { { what: 'Cafe', where: 'Zurich' } }
+
+    it 'allows to destroy by parameters directly' do
+      stub_request(:delete, "http://datastore/history?what=Cafe&where=Zurich")
+        .to_return(body: [entry].to_json)
+      deleted_entries = Record.destroy(what: 'Cafe', where: 'Zurich')
+      expect(deleted_entries.first.to_h).to eq entry
+    end
+
+    it 'allows to destroy by id' do
+      stub_request(:delete, "http://datastore/history/1")
+        .to_return(body: entry.to_json)
+      deleted_entry = Record.destroy(1)
+      expect(deleted_entry.to_h).to eq entry
+    end
+
+    it 'chains' do
+      stub_request(:delete, "http://datastore/history/1")
+        .with(headers: { 'Authorization' => 'Bearer 123' })
+        .to_return(body: entry.to_json)
+      deleted_entry = Record.options(headers: { 'Authorization' => 'Bearer 123' }).destroy(1)
+      expect(deleted_entry.to_h).to eq entry
+    end
+  end
+end


### PR DESCRIPTION
MINOR

## Destroy

You can also destroy records directly without fetching them first:

```ruby
  destroyed_record = Record.destroy('1z-5r1fkaj')
```

or with parameters:

```ruby
  destroyed_records = Record.destroy(name: 'Steve')
```