### PR TITLE
+ missing find_by! to chains

### DIFF
--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -176,6 +176,10 @@ class LHS::Record
         @record_class.find_by(params, chain_options)
       end
 
+      def find_by!(params = {})
+        @record_class.find_by!(params, chain_options)
+      end
+
       # Returns a hash of where conditions
       def where_values_hash
         chain_parameters

--- a/spec/record/find_by_chains_spec.rb
+++ b/spec/record/find_by_chains_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://datastore/records/'
+    end
+    stub_request(:get, "http://datastore/records/?limit=1&name=Steve")
+      .to_return(body: [{ name: 'Steve', color: 'blue' }].to_json)
+  end
+
+  it 'allows chaining find_by' do
+    Record.options(params: { color: 'blue' }).find_by(name: 'Steve')
+  end
+
+  it 'allows chaining find_by!' do
+    Record.options(params: { color: 'blue' }).find_by!(name: 'Steve')
+  end
+end


### PR DESCRIPTION
```ruby
Record.options(auth: { bearer: access_token }).find_by!(name: 'Steve')
```

### Current behaviour
Chains resolves before `find_by!`, returns `nil` afterwards, as `find_by!` is not available on chains.

### Expected behaviour
`find_by!` is available on chains and performs just like `Record.find_by!(args)`