### PR TITLE
! merge endpoint options when saving

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,3 +20,7 @@ Rails/OutputSafety:
 
 Style/SignalException:
   Enabled: false
+
+Rails/DynamicFindBy:
+  Enabled: false
+  

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -23,7 +23,7 @@ class LHS::Item < LHS::Proxy
         endpoint = record.find_endpoint(data)
         url = endpoint.compile(data)
         endpoint.remove_interpolated_params!(data)
-        options.merge!(endpoint.options.merge(options))
+        options.merge!(endpoint.options.merge(options)) if endpoint.options
       end
 
       options = options.merge(method: :post, url: url, body: data.to_json)

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -23,6 +23,7 @@ class LHS::Item < LHS::Proxy
         endpoint = record.find_endpoint(data)
         url = endpoint.compile(data)
         endpoint.remove_interpolated_params!(data)
+        options.merge!(endpoint.options.merge(options))
       end
 
       options = options.merge(method: :post, url: url, body: data.to_json)

--- a/spec/item/save_spec.rb
+++ b/spec/item/save_spec.rb
@@ -21,7 +21,6 @@ describe LHS::Item do
   end
 
   context 'endpoint options' do
-
     let(:headers) { { 'X-Header' => 'VALUE' } }
 
     before(:each) do
@@ -33,8 +32,8 @@ describe LHS::Item do
     it 'considers end point options when saving' do
       data = { name: 'Steve' }
       stub_request(:post, "http://datastore/records")
-         .with(body: data.to_json, headers: headers)
-         .to_return(body: data.to_json)
+        .with(body: data.to_json, headers: headers)
+        .to_return(body: data.to_json)
       RecordWithOptions.create!(data)
     end
   end

--- a/spec/item/save_spec.rb
+++ b/spec/item/save_spec.rb
@@ -20,6 +20,25 @@ describe LHS::Item do
     data[0]
   end
 
+  context 'endpoint options' do
+
+    let(:headers) { { 'X-Header' => 'VALUE' } }
+
+    before(:each) do
+      class RecordWithOptions < LHS::Record
+        endpoint 'http://datastore/records', headers: { 'X-Header' => 'VALUE' }
+      end
+    end
+
+    it 'considers end point options when saving' do
+      data = { name: 'Steve' }
+      stub_request(:post, "http://datastore/records")
+         .with(body: data.to_json, headers: headers)
+         .to_return(body: data.to_json)
+      RecordWithOptions.create!(data)
+    end
+  end
+
   context 'save' do
     it 'persists changes on the backend' do
       stub_request(:post, item.href).with(body: item._raw.merge(name: 'Steve').to_json)


### PR DESCRIPTION
Patch Version

## Expected Behaviour
```ruby
class RecordWithOptions < LHS::Record
  endpoint 'http://datastore/records', headers: { 'X-Header' => 'VALUE' }
end

RecordWithOptions.save(some: 'thing')
```
It should merge endpoint headers to the request done saving the record.

## Current Behaviour
It does not merge any endpoint options at all!