### PR TITLE
There are errors

### DIFF
--- a/lib/lhs/errors.rb
+++ b/lib/lhs/errors.rb
@@ -65,6 +65,7 @@ class LHS::Errors
   private
 
   def add_error(messages, key, value)
+    key = key.to_sym
     messages[key] ||= []
     messages[key].push(value)
   end
@@ -81,6 +82,11 @@ class LHS::Errors
     if json['field_errors']
       json['field_errors'].each do |field_error|
         add_error(messages, field_error['path'].join('.').to_sym, field_error['code'])
+      end
+    end
+    if messages.empty? && json.present?
+      json.each do |key, value|
+        add_error(messages, key, value)
       end
     end
     messages

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -112,6 +112,8 @@ describe LHS::Item do
       expect(result).to eq false
       expect(record.errors).to be
       expect(record.errors.any?).to eq true
+      expect(record.errors['error']).to eq ['missing_token']
+      expect(record.errors['error_description']).to eq ['Bearer token is missing']
     end
   end
 
@@ -124,6 +126,7 @@ describe LHS::Item do
       expect(result).to eq false
       expect(record.errors).to be
       expect(record.errors.any?).to eq true
+      expect(record.errors['body']).to eq ['parse error']
     end
   end
 end

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -114,4 +114,16 @@ describe LHS::Item do
       expect(record.errors.any?).to eq true
     end
   end
+
+  context 'empty error response body' do
+    it 'still tells us that there is an error' do
+      stub_request(:post, "#{datastore}/feedbacks").to_return(status: 400)
+      record = Record.build
+      record.name = 'Steve'
+      result = record.save
+      expect(result).to eq false
+      expect(record.errors).to be
+      expect(record.errors.any?).to eq true
+    end
+  end
 end


### PR DESCRIPTION
PATCH VERSION

Context: validating business objects (create, update)

## Before:

In case of a custom structure content in the response body of a error response, lhs was not storing any error messages in errors. So methods like `save`, `update` etc. have been returning the boolean indicating if save or updated succeeded, but asking the `errors` object on the specific instance was telling us the opposite: no error.

This could lead to inconsistent states.

## Now:

In case of any LHC::Error the `errors` object returns and informs about errors.