### PR TITLE
! save endpoint with compiled params

### DIFF
--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -14,15 +14,15 @@ class LHS::Item < LHS::Proxy
     end
 
     def save!(options = {})
-      options ||= {}
-      record = _data.class
+      options = options.present? ? options.dup : {}
       data = _data._raw.dup
       if href.present?
         url = href
       else
-        endpoint = record.find_endpoint(data)
-        url = endpoint.compile(data)
+        endpoint = endpoint_for_persistance(data, options)
+        url = url_for_persistance(endpoint, data, options)
         endpoint.remove_interpolated_params!(data)
+        endpoint.remove_interpolated_params!(options.fetch(:params, {}))
         options.merge!(endpoint.options.merge(options)) if endpoint.options
       end
 
@@ -30,9 +30,34 @@ class LHS::Item < LHS::Proxy
       options[:headers] ||= {}
       options[:headers].merge!('Content-Type' => 'application/json')
 
-      data = record.request(options)
+      data = record_for_persistance.request(options)
       _data.merge_raw!(data)
       true
+    end
+
+    private
+
+    def endpoint_for_persistance(data, options)
+      record_for_persistance
+        .find_endpoint(merge_data_with_options(data, options))
+    end
+
+    def merge_data_with_options(data, options)
+      if options && options[:params]
+        data.merge(options[:params])
+      else
+        data
+      end
+    end
+
+    def record_for_persistance
+      _data.class
+    end
+
+    def url_for_persistance(endpoint, data, options)
+      endpoint.compile(
+        merge_data_with_options(data, options)
+      )
     end
   end
 end

--- a/spec/record/save_spec.rb
+++ b/spec/record/save_spec.rb
@@ -14,14 +14,24 @@ describe LHS::Record do
       let(:campaign_id) { 12345 }
       let(:object) { { recommended: true } }
       let(:item) { Feedback.new(object.merge(campaign_id: campaign_id)) }
-
-      it 'removes params used to compute url from send data' do
-        datastore_request = stub_request(:post, "#{datastore}/content-ads/#{campaign_id}/feedbacks")
+      let!(:request) do
+        stub_request(:post, "#{datastore}/content-ads/#{campaign_id}/feedbacks")
           .with(body: object.to_json)
           .to_return(status: 200, body: object.to_json)
+      end
 
+      it 'removes params used to compute url from send data' do
         item.save!
-        expect(datastore_request).to have_been_made.once
+        expect(request).to have_been_made.once
+      end
+
+      context 'item without data' do
+        let(:item) { Feedback.new(object) }
+
+        it 'takes params to find endpoint also from the options' do
+          item.save!(params: { campaign_id: campaign_id })
+          expect(request).to have_been_made.once
+        end
       end
     end
   end


### PR DESCRIPTION
PATCH VERSION

## BEFORE
It was not able to compile urls for persistance through params. Everything had to be in the body, the items raw data, in order to have it available for endpoint selection and url compiling.
```ruby
class ContactPerson < LHS::Record
  endpoint ':lcm/customers/:customer_id/contact_persons'
end
item = ContactPerson.new(name: 'Sebastian')
item.save(params: { customer_id: 123 })
# RAISES: compiliation incomplete, no value for customer_id
```

The workaround before was to just store the data required for detecting and compiling the endpoint inside the item:
```ruby
item.customer_id = 123
item.save
# true
```
But this requires that the particular endpoint has to ignore that data, as we are also sending it as part of the body. LCM does not, they are raising exceptions if data is send through the body, which is unknown, what is okay. But this lead to this PR.

# NOW
```ruby
class ContactPerson < LHS::Record
  endpoint ':lcm/customers/:customer_id/contact_persons'
end
item = ContactPerson.new(name: 'Sebastian')
item.save(params: { customer_id: 123 })
# true
```