### PR TITLE
! a more complex includes and references case

### DIFF
--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -256,7 +256,7 @@ class LHS::Record
 
       def resolved_options
         options = chain_options
-        options = options.merge(params: chain_parameters.merge(chain_pagination))
+        options = options.deep_merge(params: chain_parameters.merge(chain_pagination))
         options = options.merge(error_handler: chain_error_handler) if chain_error_handler.present?
         options = options.merge(including: chain_includes) if chain_includes.present?
         options = options.merge(referencing: chain_references) if chain_references.present?

--- a/lib/lhs/concerns/record/find_by.rb
+++ b/lib/lhs/concerns/record/find_by.rb
@@ -22,7 +22,7 @@ class LHS::Record
 
       def _find_by(params, options = {})
         options ||= {}
-        params = params.dup.merge(limit: 1)
+        params = params.dup.merge(limit: 1).merge(options.fetch(:params, {}))
         data = request(options.merge(params: params))
         if data._proxy.is_a?(LHS::Collection)
           data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -109,7 +109,7 @@ class LHS::Record
         return if data.blank? || skip_loading_includes?(data, included)
         options = options_for_data(data, included)
         options = extend_with_references(options, references)
-        addition = load_include(options, data, sub_includes)
+        addition = load_include(options, data, sub_includes, references)
         extend_raw_data!(data, addition, included)
         expand_addition!(data, included) if no_expanded_data?(addition)
       end
@@ -162,14 +162,14 @@ class LHS::Record
       end
 
       # Load additional resources that are requested with include
-      def load_include(options, data, sub_includes)
+      def load_include(options, data, sub_includes, references)
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         begin
           if options.is_a?(Array)
-            options.each { |options| options.merge!(including: sub_includes) if sub_includes.present? }
+            options.each { |options| options.merge!(including: sub_includes, referencing: references) if sub_includes.present? }
           elsif sub_includes.present?
-            options.merge!(including: sub_includes)
+            options.merge!(including: sub_includes, referencing: references)
           end
           record.request(options)
         rescue LHC::NotFound

--- a/spec/record/find_by_chains_spec.rb
+++ b/spec/record/find_by_chains_spec.rb
@@ -5,7 +5,7 @@ describe LHS::Record do
     class Record < LHS::Record
       endpoint 'http://datastore/records/'
     end
-    stub_request(:get, "http://datastore/records/?limit=1&name=Steve")
+    stub_request(:get, "http://datastore/records/?limit=1&name=Steve&color=blue")
       .to_return(body: [{ name: 'Steve', color: 'blue' }].to_json)
   end
 

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -416,7 +416,7 @@ describe LHS::Record do
     end
 
     it 'forwards complex references' do
-      stub_request(:get, "http://datastore/places/123?limit=1")
+      stub_request(:get, "http://datastore/places/123?limit=1&forwarded_params=for_place")
         .to_return(body: {
           'contracts' => {
             'href' => "http://datastore/places/123/contracts"
@@ -435,7 +435,7 @@ describe LHS::Record do
           'name' => 'Local Logo'
         }.to_json)
       place = Place
-        .options(forward_params: 'for_place')
+        .options(params: { forwarded_params: 'for_place' })
         .includes(contracts: :product)
         .references(
           contracts: {


### PR DESCRIPTION
PATCH VERSION

## BEFORE
A specific, complex `includes` and `references` case failed. One we had in SB:

```ruby
Place
  .options(auth: { bearer: token })
  .includes(contracts: :product)
  .references(contracts: { auth: { bearer: token }, product: { auth: { bearer: token } } })
  .find_by(id: online_entry_identifier)
```

Load place with auth token. Include contracts linked from place and the product, linked from any contract within place. Use auth token requesting place, contracts, and products.

Referencing deeper than one level failed (as you can see from the patch).

## NOW
Referencing is forwarded properly, so we can authenticate requests made to data included over multiple levels.