### PR TITLE
fix expanding empty arrays

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -39,7 +39,6 @@ class LHS::Record
 
       # Extends existing raw data with additionaly fetched data
       def extend_raw_data!(data, addition, key)
-        return if addition.empty?
         if data.collection?
           extend_base_collection!(data, addition, key)
         elsif data[key]._raw.is_a? Array

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -462,7 +462,10 @@ describe LHS::Record do
           items: []
         }.to_json)
       place = Place.includes(:contracts).find('123')
-      expect(place.contracts._raw[:items]).to eq []
+      expect(
+        place.contracts.as_json
+      ).to eq('href' => 'http://datastore/places/123/contracts', 'items' => [])
+      expect(place.contracts.to_a).to eq([])
     end
   end
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -462,6 +462,7 @@ describe LHS::Record do
           items: []
         }.to_json)
       place = Place.includes(:contracts).find('123')
+      expect(place.contracts.collection?).to eq true
       expect(
         place.contracts.as_json
       ).to eq('href' => 'http://datastore/places/123/contracts', 'items' => [])

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -448,5 +448,21 @@ describe LHS::Record do
         place.contracts.first.product.name
       ).to eq 'Local Logo'
     end
+
+    it 'expands empty arrays' do
+      stub_request(:get, "http://datastore/places/123")
+        .to_return(body: {
+          'contracts' => {
+            'href' => "http://datastore/places/123/contracts"
+          }
+        }.to_json)
+      stub_request(:get, "http://datastore/places/123/contracts")
+        .to_return(body: {
+          href: "http://datastore/places/123/contracts",
+          items: []
+        }.to_json)
+      place = Place.includes(:contracts).find('123')
+      expect(place.contracts._raw[:items]).to eq []
+    end
   end
 end


### PR DESCRIPTION
*PATCH VERSION*

## BEFORE

LHS was not expanding empty arrays. Wich turns out to be nil when accessing the nested data, instead of being an empty array, which would be actually more concrete.

```ruby
place = Place.includes(:contracts) # requesting contracts => { items: [] }
place.contracts # nil
```

## NOW

```ruby
place.contracts
# Data of Place#70252363673400
# :href => "http://datastore/places/123/contracts"
# :items => []
```