### PR TITLE
! parse error when body is unparsable

### DIFF
--- a/lib/lhs/errors.rb
+++ b/lib/lhs/errors.rb
@@ -5,11 +5,13 @@ class LHS::Errors
   attr_reader :messages, :message, :raw
 
   def initialize(response = nil)
+    @raw = response.body if response
     @messages = messages_from_response(response)
     @message = message_from_response(response)
-    @raw = response.body if response
   rescue JSON::ParserError
-    add_error(messages, 'body', 'parse error')
+    @messages = messages || {}
+    @message = 'parse error'
+    add_error(@messages, 'body', 'parse error')
   end
 
   def include?(attribute)

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -46,6 +46,10 @@ describe LHS::Item do
     }
   end
 
+  let(:unparsable_error_body) do
+    '<html></html>'
+  end
+
   before(:each) do
     LHC.config.placeholder(:datastore, datastore)
     class Record < LHS::Record
@@ -120,6 +124,19 @@ describe LHS::Item do
   context 'empty error response body' do
     it 'still tells us that there is an error' do
       stub_request(:post, "#{datastore}/feedbacks").to_return(status: 400)
+      record = Record.build
+      record.name = 'Steve'
+      result = record.save
+      expect(result).to eq false
+      expect(record.errors).to be
+      expect(record.errors.any?).to eq true
+      expect(record.errors['body']).to eq ['parse error']
+    end
+  end
+
+  context 'unparsable error body' do
+    it 'still tells us that there is an error' do
+      stub_request(:post, "#{datastore}/feedbacks").to_return(status: 400, body: unparsable_error_body)
       record = Record.build
       record.name = 'Steve'
       result = record.save


### PR DESCRIPTION
*PATCH VERSION*

Validation  error messages that where unparsable where raising another problem, as `@messages` and `@message` was not when catching the error.