### PR TITLE
! validation url compiled with locally passed params

### DIFF
--- a/lib/lhs/concerns/item/validation.rb
+++ b/lib/lhs/concerns/item/validation.rb
@@ -11,7 +11,7 @@ class LHS::Item < LHS::Proxy
       endpoint = validation_endpoint
       raise 'No endpoint found to perform validations! See here: https://github.com/local-ch/lhs#validation' unless endpoint
       record = LHS::Record.for_url(endpoint.url)
-      params = merge_validation_params!(endpoint)
+      params = merge_validation_params!(endpoint).merge options.fetch(:params, {})
       url = validation_url(endpoint)
       run_validation!(record, options, url, params)
       true

--- a/spec/item/validation_spec.rb
+++ b/spec/item/validation_spec.rb
@@ -110,4 +110,20 @@ describe LHS::Item do
       end).to raise_error('Endpoint does not support validations!')
     end
   end
+
+  context 'generate validation url from locally passed params' do
+    before(:each) do
+      class User < LHS::Record
+        endpoint 'http://datastore/v2/users/:user_id', validates: { params: { persist: false } }
+      end
+    end
+
+    it 'takes local params when generating validation url' do
+      stub_request(:post, "http://datastore/v2/users/2?persist=false")
+        .to_return(status: 201)
+      expect(
+        user.valid?(params: { user_id: 2 })
+      ).to eq true
+    end
+  end
 end


### PR DESCRIPTION
When required parameters for validation url compilation have to be passed with local options, this was not working.

## BEFORE

```ruby
class User < LHS::Record
  endpoint 'http://datastore/v2/users/:user_id', validates: { params: { persist: false } }
end

user = User.build(email: 'steve@cloudy.com')
user.valid?(params: { user_id: 2 })
# Raises Error: validation incomplete
```

## NOW

```ruby
user = User.build(email: 'steve@cloudy.com')
user.valid?(params: { user_id: 2 })
# true
```