### PR TITLE
Load and merge created data through location header

### DIFF
--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -15,29 +15,34 @@ class LHS::Item < LHS::Proxy
     def save!(options = {})
       options = options.present? ? options.dup : {}
       data = _data._raw.dup
-      if href.present?
-        url = href
-      else
-        endpoint = endpoint_for_persistance(data, options)
-        url = url_for_persistance(endpoint, data, options)
-        endpoint.remove_interpolated_params!(data)
-        endpoint.remove_interpolated_params!(options.fetch(:params, {}))
-        options.merge!(endpoint.options.merge(options)) if endpoint.options
-      end
-
-      options = options.merge(method: :post, url: url, body: data.to_json)
-      options[:headers] ||= {}
-      options[:headers].merge!('Content-Type' => 'application/json')
-
-      data = record_for_persistance.request(options)
-      _data.merge_raw!(data)
-      true
+      url = url_for_persistance!(options, data)
+      create_and_merge_data!(
+        apply_default_creation_options(options, url, data)
+      )
     rescue LHC::Error => e
       self.errors = LHS::Errors.new(e.response)
       raise e
     end
 
     private
+
+    def apply_default_creation_options(options, url, data)
+      options = options.merge(method: :post, url: url, body: data.to_json)
+      options[:headers] ||= {}
+      options[:headers].merge!('Content-Type' => 'application/json')
+      options
+    end
+
+    def create_and_merge_data!(options)
+      direct_response_data = record_for_persistance.request(options)
+      _data.merge_raw!(direct_response_data)
+      response_headers = direct_response_data._request.response.headers
+      if response_headers && response_headers['Location']
+        location_data = record_for_persistance.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
+        _data.merge_raw!(location_data)
+      end
+      true
+    end
 
     def endpoint_for_persistance(data, options)
       record_for_persistance
@@ -56,10 +61,19 @@ class LHS::Item < LHS::Proxy
       _data.class
     end
 
-    def url_for_persistance(endpoint, data, options)
-      endpoint.compile(
-        merge_data_with_options(data, options)
-      )
+    def url_for_persistance!(options, data)
+      if href.present?
+        href
+      else
+        endpoint = endpoint_for_persistance(data, options)
+        url = endpoint.compile(
+          merge_data_with_options(data, options)
+        )
+        endpoint.remove_interpolated_params!(data)
+        endpoint.remove_interpolated_params!(options.fetch(:params, {}))
+        options.merge!(endpoint.options.merge(options)) if endpoint.options
+        url
+      end
     end
   end
 end

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -66,7 +66,7 @@ class LHS::Item < LHS::Proxy
       endpoint = endpoint_for_persistance(data, options)
       endpoint.compile(
         merge_data_with_options(data, options)
-      ).tap do 
+      ).tap do
         endpoint.remove_interpolated_params!(data)
         endpoint.remove_interpolated_params!(options.fetch(:params, {}))
         options.merge!(endpoint.options.merge(options)) if endpoint.options

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -62,17 +62,14 @@ class LHS::Item < LHS::Proxy
     end
 
     def url_for_persistance!(options, data)
-      if href.present?
-        href
-      else
-        endpoint = endpoint_for_persistance(data, options)
-        url = endpoint.compile(
-          merge_data_with_options(data, options)
-        )
+      return href if href.present?
+      endpoint = endpoint_for_persistance(data, options)
+      endpoint.compile(
+        merge_data_with_options(data, options)
+      ).tap do 
         endpoint.remove_interpolated_params!(data)
         endpoint.remove_interpolated_params!(options.fetch(:params, {}))
         options.merge!(endpoint.options.merge(options)) if endpoint.options
-        url
       end
     end
   end

--- a/spec/record/create_spec.rb
+++ b/spec/record/create_spec.rb
@@ -131,5 +131,29 @@ describe LHS::Record do
         end
       end
     end
+
+    context 'location header' do
+
+      before(:each) do
+        class ContactPerson < LHS::Record
+          endpoint 'http://datastore/contact_persons'
+        end
+      end
+
+      let(:location)   { 'http://datastore/contact_persons/1' }
+      let(:created_at) { '2017-12-21' }
+      let(:name)       { 'Sebastian' }
+
+      it 'Loads the data from the "Location" header after creation' do
+        stub_request(:post, "http://datastore/contact_persons")
+          .to_return(status: 204, headers: { Location: location })
+        stub_request(:get, "http://datastore/contact_persons/1")
+          .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
+        contact_person = ContactPerson.create!(name: name)
+        expect(contact_person.href).to eq location
+        expect(contact_person.created_at).to eq Date.parse(created_at)
+        expect(contact_person.name).to eq name
+      end
+    end
   end
 end

--- a/spec/record/create_spec.rb
+++ b/spec/record/create_spec.rb
@@ -133,7 +133,6 @@ describe LHS::Record do
     end
 
     context 'location header' do
-
       before(:each) do
         class ContactPerson < LHS::Record
           endpoint 'http://datastore/contact_persons'


### PR DESCRIPTION
*PATCH VERSION*

When creating records, location header has not been considered when creation endpoint returns no content.

## BEFORE

```ruby
contact_person = ContactPerson.create(first_name: 'Sebastian')
# POST http://datastore/contact_persons
# RETURNS 204 body: '', headers: { Location: 'http://datastore/contact_persons/1' }
contact_person.href # nil
```

## NOW

Location-Header is considered, fetched and merged with raw data if creation endpoint provides such header on creation.

```ruby
contact_person = ContactPerson.create(first_name: 'Sebastian')
contact_person.href # http://datastore/contact_persons/1
```