### PR TITLE
Fix referencing options in case includes is an array of symbols

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,5 @@ Style/SignalException:
 Rails/DynamicFindBy:
   Enabled: false
   
+Metrics/BlockLength:
+  Enabled: false

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -92,12 +92,11 @@ class LHS::Record
 
       def handle_includes(includes, data, references = {})
         references ||= {}
-        references = [references] if includes.is_a?(Array) && !references.is_a?(Array)
         if includes.is_a? Hash
           includes.each { |included, sub_includes| handle_include(included, data, sub_includes, references[included]) }
         elsif includes.is_a? Array
           includes.each_with_index do |included, index|
-            handle_includes(included, data, references[index])
+            handle_includes(included, data, references)
           end
         else
           handle_include(includes, data, nil, references[includes])

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -95,7 +95,7 @@ class LHS::Record
         if includes.is_a? Hash
           includes.each { |included, sub_includes| handle_include(included, data, sub_includes, references[included]) }
         elsif includes.is_a? Array
-          includes.each_with_index do |included, index|
+          includes.each do |included|
             handle_includes(included, data, references)
           end
         else

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -468,7 +468,5 @@ describe LHS::Record do
       ).to eq('href' => 'http://datastore/places/123/contracts', 'items' => [])
       expect(place.contracts.to_a).to eq([])
     end
-
-    
   end
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -468,5 +468,7 @@ describe LHS::Record do
       ).to eq('href' => 'http://datastore/places/123/contracts', 'items' => [])
       expect(place.contracts.to_a).to eq([])
     end
+
+    
   end
 end

--- a/spec/record/references_spec.rb
+++ b/spec/record/references_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe LHS::Record do
-
   context 'references' do
     before(:each) do
       class Customer < LHS::Record
@@ -34,11 +33,11 @@ describe LHS::Record do
     end
 
     let(:referencing_options) do
-      { headers: { 'Authentication': 'Bearer 123' } }
+      { headers: { 'Authentication' => 'Bearer 123' } }
     end
 
     it 'uses the "references" hash for all symbols of the "including" array' do
-      customer = Customer
+      Customer
         .includes(:electronic_addresses, :contact_addresses)
         .references(
           electronic_addresses: referencing_options,

--- a/spec/record/references_spec.rb
+++ b/spec/record/references_spec.rb
@@ -1,33 +1,35 @@
+require 'rails_helper'
+
 describe LHS::Record do
 
   context 'references' do
     before(:each) do
       class Customer < LHS::Record
-        endpoint ':datastore/customers/:id'
+        endpoint 'http://datastore/customers/:id'
       end
     end
 
     let!(:customer_request) do
-      stub_request(:get, "#{datastore}/customers/1")
+      stub_request(:get, "http://datastore/customers/1")
         .to_return(body: {
           'electronic_addresses' => {
-            'href' => "#{datastore}/electronic_addresses"
+            'href' => "http://datastore/electronic_addresses"
           },
           'contact_addresses' => {
-            'href' => "#{datastore}/contact_addresses"
+            'href' => "http://datastore/contact_addresses"
           }
         }.to_json)
     end
 
     let!(:electronic_addresses_request) do
-      stub_request(:get, "http://local.ch/v2/electronic_addresses")
-        .with(headers: { 'Authentication' => "Bearer 123" })
+      stub_request(:get, "http://datastore/electronic_addresses")
+        .with(referencing_options)
         .to_return(body: [].to_json)
     end
 
     let!(:contact_addresses_request) do
-      stub_request(:get, "http://local.ch/v2/contact_addresses")
-        .with(headers: { 'Authentication' => "Bearer 123" })
+      stub_request(:get, "http://datastore/contact_addresses")
+        .with(referencing_options)
         .to_return(body: [].to_json)
     end
 
@@ -43,8 +45,6 @@ describe LHS::Record do
           contact_addresses: referencing_options
         )
         .find(1)
-      expect(customer.electronic_addresses).to eq []
-      expect(customer.contact_addresses).to eq []
       assert_requested(electronic_addresses_request)
       assert_requested(contact_addresses_request)
     end

--- a/spec/record/references_spec.rb
+++ b/spec/record/references_spec.rb
@@ -1,0 +1,52 @@
+describe LHS::Record do
+
+  context 'references' do
+    before(:each) do
+      class Customer < LHS::Record
+        endpoint ':datastore/customers/:id'
+      end
+    end
+
+    let!(:customer_request) do
+      stub_request(:get, "#{datastore}/customers/1")
+        .to_return(body: {
+          'electronic_addresses' => {
+            'href' => "#{datastore}/electronic_addresses"
+          },
+          'contact_addresses' => {
+            'href' => "#{datastore}/contact_addresses"
+          }
+        }.to_json)
+    end
+
+    let!(:electronic_addresses_request) do
+      stub_request(:get, "http://local.ch/v2/electronic_addresses")
+        .with(headers: { 'Authentication' => "Bearer 123" })
+        .to_return(body: [].to_json)
+    end
+
+    let!(:contact_addresses_request) do
+      stub_request(:get, "http://local.ch/v2/contact_addresses")
+        .with(headers: { 'Authentication' => "Bearer 123" })
+        .to_return(body: [].to_json)
+    end
+
+    let(:referencing_options) do
+      { headers: { 'Authentication': 'Bearer 123' } }
+    end
+
+    it 'uses the "references" hash for all symbols of the "including" array' do
+      customer = Customer
+        .includes(:electronic_addresses, :contact_addresses)
+        .references(
+          electronic_addresses: referencing_options,
+          contact_addresses: referencing_options
+        )
+        .find(1)
+      expect(customer.electronic_addresses).to eq []
+      expect(customer.contact_addresses).to eq []
+      assert_requested(electronic_addresses_request)
+      assert_requested(contact_addresses_request)
+    end
+  end
+end


### PR DESCRIPTION
*PATCH VERSION*

## Before
It was not possible to apply the `references` options to all symbols of the `includes` array.

```ruby
options = { headers: { 'Authentication': 'Bearer 123' } }
customer = Customer
  .includes(:electronic_addresses, :contact_addresses)
  .references(
    electronic_addresses: options,
    contact_addresses: options
  )
  .find(1)
```

It was failing, because by mistake, the `references` hash was converted to an array internally, being applied only on the first symbol of the `includes` array.

## Now

The `references` hash, as expected, gets applied to all symbols in the `includes` array, according to their key: `:electronic_addresses` => `electronic_addresses: options`, etc.