### PR TITLE
Fix unique multiple endpoint bug, when including nested data

### DIFF
--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -36,8 +36,10 @@ class LHS::Record
       # Find an endpoint based on the provided parameters.
       # If no parameters are provided it finds the base endpoint
       # otherwise it finds the endpoint that matches the parameters best.
-      def find_endpoint(params = {})
+      def find_endpoint(params = {}, url = nil)
         endpoint = find_best_endpoint(params) if params && params.keys.count > 0
+        endpoint ||= find_endpoint_by_url(url) if url.present?
+        endpoint ||= LHC::Endpoint.new(url) if url.present?
         endpoint ||= find_base_endpoint
         endpoint
       end
@@ -77,6 +79,13 @@ class LHS::Record
       def find_best_endpoint(params)
         sorted_endpoints.find do |endpoint|
           endpoint.placeholders.all? { |match| endpoint.find_value(match, params) }
+        end
+      end
+
+      # Find endpoint by given URL
+      def find_endpoint_by_url(url)
+        sorted_endpoints.find do |endpoint|
+          LHC::Endpoint.match?(url, endpoint.url)
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -292,7 +292,7 @@ class LHS::Record
       def multiple_requests(options)
         options = options.map do |option|
           next unless option.present?
-          process_options(option, find_endpoint(option[:params]))
+          process_options(option, find_endpoint(option[:params], option.fetch(:url, nil)))
         end
         data = LHC.request(options.compact).map do |response|
           LHS::Data.new(response.body, nil, self, response.request)
@@ -395,7 +395,7 @@ class LHS::Record
         options = options.dup
         including = options.delete(:including)
         referencing = options.delete(:referencing)
-        endpoint = find_endpoint(options[:params])
+        endpoint = find_endpoint(options[:params], options.fetch(:url, nil))
         apply_limit!(options) if options[:all]
         response = LHC.request(process_options(options, endpoint))
         data = LHS::Data.new(response.body, nil, self, response.request, endpoint)

--- a/spec/record/endpoints_spec.rb
+++ b/spec/record/endpoints_spec.rb
@@ -83,7 +83,7 @@ describe LHS::Record do
           .to_return(body: [{ product: { href: "#{datastore}/products/LBC" } }].to_json)
         stub_request(:get, "#{datastore}/products/LBC")
           .to_return(body: { name: 'Local Business Card' }.to_json)
-        expect(lambda{
+        expect(lambda {
           Contract.includes(:product).where(entry_id: '123').all.first
         }).not_to raise_error # Multiple base endpoints found
       end

--- a/spec/record/endpoints_spec.rb
+++ b/spec/record/endpoints_spec.rb
@@ -69,5 +69,24 @@ describe LHS::Record do
         AnotherRecord.where(campaign_id: 123, entry_id: 123)
       end
     end
+
+    context 'includes data without considering base endpoint of parent record if url is present' do
+      before(:each) do
+        class Contract < LHS::Record
+          endpoint ':datastore/contracts/:id'
+          endpoint ':datastore/entry/:entry_id/contracts'
+        end
+      end
+
+      it 'uses urls instead of trying to find base endpoint of parent class' do
+        stub_request(:get, "#{datastore}/entry/123/contracts?limit=100")
+          .to_return(body: [{ product: { href: "#{datastore}/products/LBC" } }].to_json)
+        stub_request(:get, "#{datastore}/products/LBC")
+         .to_return(body: { name: 'Local Business Card' }.to_json)
+        expect(->{
+          Contract.includes(:product).where(entry_id: '123').all.first
+        }).not_to raise_error # Multiple base endpoints found
+      end
+    end
   end
 end

--- a/spec/record/endpoints_spec.rb
+++ b/spec/record/endpoints_spec.rb
@@ -82,8 +82,8 @@ describe LHS::Record do
         stub_request(:get, "#{datastore}/entry/123/contracts?limit=100")
           .to_return(body: [{ product: { href: "#{datastore}/products/LBC" } }].to_json)
         stub_request(:get, "#{datastore}/products/LBC")
-         .to_return(body: { name: 'Local Business Card' }.to_json)
-        expect(->{
+          .to_return(body: { name: 'Local Business Card' }.to_json)
+        expect(lambda{
           Contract.includes(:product).where(entry_id: '123').all.first
         }).not_to raise_error # Multiple base endpoints found
       end


### PR DESCRIPTION
*PATCH VERSION*

## Before

It was not possible to include nested data, in case the Record definition was not containing a unique, parameterless base endpoint. Includes tried to finding parents base endpoint, even though urls are around, which led to the "Multiple Base Endpoints" exception. 

```ruby
class Contract < LHS::Record
  endpoint ':datastore/contracts/:id'
  endpoint ':datastore/entry/:entry_id/contracts'
end

Contract.includes(:product).where(entry_id: '123').all.first
# raises 'Multiple base endpoints found'
```

## Now

It does not raise anymore, as base endpoints are not looked up anymore, as nested data contains the urls already. 