### PR TITLE
Fix includes all for empty arrays

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -175,7 +175,7 @@ class LHS::Record
       def load_and_merge_remaining_objects!(data, options)
         if paginated?(data._raw)
           load_and_merge_paginated_collection!(data, options)
-        elsif data.collection? && paginated?(data.first.try(&:_raw))
+        elsif data.collection? && paginated?(data.first.try(:_raw))
           load_and_merge_set_of_paginated_collections!(data, options)
         end
       end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -175,7 +175,7 @@ class LHS::Record
       def load_and_merge_remaining_objects!(data, options)
         if paginated?(data._raw)
           load_and_merge_paginated_collection!(data, options)
-        elsif data.collection? && paginated?(data.first._raw)
+        elsif data.collection? && paginated?(data.first.try(&:_raw))
           load_and_merge_set_of_paginated_collections!(data, options)
         end
       end

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -115,5 +115,25 @@ describe LHS::Record do
       expect(products_request_page_2).to have_been_requested.at_least_once
       expect(products_request_page_3).to have_been_requested.at_least_once
     end
+
+    context 'includes for an empty array' do
+
+      before(:each) do
+        class Contract < LHS::Record
+          endpoint 'http://datastore/contracts/:id'
+        end
+        stub_request(:get, "http://datastore/contracts/1")
+          .to_return(body: {
+            options: []
+          }.to_json)
+      end
+
+      it 'includes_all in case of an empty array' do
+        contract = Contract
+          .includes(:product)
+          .includes_all(:options)
+          .find(1)
+      end
+    end
   end
 end

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -117,7 +117,6 @@ describe LHS::Record do
     end
 
     context 'includes for an empty array' do
-
       before(:each) do
         class Contract < LHS::Record
           endpoint 'http://datastore/contracts/:id'
@@ -129,10 +128,12 @@ describe LHS::Record do
       end
 
       it 'includes_all in case of an empty array' do
-        contract = Contract
-          .includes(:product)
-          .includes_all(:options)
-          .find(1)
+        expect(lambda do
+          Contract
+            .includes(:product)
+            .includes_all(:options)
+            .find(1)
+        end).not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Fixes case where response contains empty array but LHS tries to access `._raw` on empty array.