### PR TITLE
+ test case for includes

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -62,8 +62,8 @@ class LHS::Record
           item = item[i] if item.is_a? LHS::Collection
           link = item[key.to_sym]
           if link && link.collection?
-            link.each_with_index do |link, j|
-              link.merge_raw!(addition[i + j]) if link.present?
+            link.each_with_index do |item, j|
+              item.merge_raw!(addition[i + j]) if item.present?
             end
           elsif link.present?
             link.merge_raw!(addition[i])
@@ -413,8 +413,8 @@ class LHS::Record
       def url_option_for(item, key = nil)
         link = key ? item[key] : item
         if link && link.collection?
-          link.map do |link|
-            { url: link.href } if link.present? && link.href.present?
+          link.map do |item|
+            { url: item.href } if item.present? && item.href.present?
           end.compact
         elsif link.present? && link.href.present?
           { url: link.href }

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -65,8 +65,8 @@ class LHS::Record
             link.each_with_index do |link, j|
               link.merge_raw!(addition[i + j]) if link.present?
             end
-          else
-            link.merge_raw!(addition[i]) if link.present?
+          elsif link.present?
+            link.merge_raw!(addition[i])
           end
         end
       end
@@ -416,8 +416,8 @@ class LHS::Record
           link.map do |link|
             { url: link.href } if link.present? && link.href.present?
           end.compact
-        else
-          return { url: link.href } if link.present? && link.href.present?
+        elsif link.present? && link.href.present?
+          { url: link.href }
         end
       end
     end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -61,12 +61,11 @@ class LHS::Record
         data.each_with_index do |item, i|
           item = item[i] if item.is_a? LHS::Collection
           link = item[key.to_sym]
-          if link && link.collection?
-            link.each_with_index do |item, j|
-              item.merge_raw!(addition[i + j]) if item.present?
-            end
-          elsif link.present?
-            link.merge_raw!(addition[i])
+          next if link.blank?
+          link.merge_raw!(addition[i]) && next if !link.collection?
+
+          link.each_with_index do |item, j|
+            item.merge_raw!(addition[i + j]) if item.present?
           end
         end
       end
@@ -412,13 +411,12 @@ class LHS::Record
 
       def url_option_for(item, key = nil)
         link = key ? item[key] : item
-        if link && link.collection?
-          link.map do |item|
-            { url: item.href } if item.present? && item.href.present?
-          end.compact
-        elsif link.present? && link.href.present?
-          { url: link.href }
-        end
+        return if link.blank?
+        return { url: link.href } if !link.collection?
+
+        link.map do |item|
+          { url: item.href } if item.present? && item.href.present?
+        end.compact
       end
     end
   end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -480,14 +480,10 @@ describe LHS::Record do
         .to_return(body:{
           category_relations: [{
             "href": "http://datastore/category/1"
-          }, {
-            "href": "http://datastore/category/2"
           }]
         }.to_json)
       stub_request(:get, "http://datastore/category/1")
         .to_return(body: { name: 'Food' }.to_json)
-      stub_request(:get, "http://datastore/category/2")
-        .to_return(body: { name: 'Drinks' }.to_json)
     end
 
     it 'includes and merges linked resources in case of an array of links' do

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -479,17 +479,18 @@ describe LHS::Record do
       stub_request(:get, "http://datastore/places/1")
         .to_return(body:{
           category_relations: [{
-            "href": "http://datastore/categorie/2"
+            "href": "http://datastore/category/2"
           }]
         }.to_json)
-      stub_request(:get, "http://datastore/categorie/2")
+      stub_request(:get, "http://datastore/category/2")
         .to_return(body: { name: 'Food' }.to_json)
     end
 
     it 'includes and merges linked resources in case of an array of links' do
-      Place
+      place = Place
         .includes(:category_relations)
         .find(1)
+      expect(place.category_relations.first.name).to eq 'Food'
     end
   end
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -471,18 +471,17 @@ describe LHS::Record do
   end
 
   context 'include and merge arrays when calling find in parallel' do
-
     before(:each) do
       class Place < LHS::Record
         endpoint 'http://datastore/places/:id'
       end
       stub_request(:get, 'http://datastore/places/1')
         .to_return(body: {
-          category_relations: [{ 'href': 'http://datastore/category/1' }, { 'href': 'http://datastore/category/2' }]
+          category_relations: [{ href: 'http://datastore/category/1' }, { href: 'http://datastore/category/2' }]
         }.to_json)
       stub_request(:get, 'http://datastore/places/2')
         .to_return(body: {
-          category_relations: [{ 'href': 'http://datastore/category/2' }, { 'href': 'http://datastore/category/1' }]
+          category_relations: [{ href: 'http://datastore/category/2' }, { href: 'http://datastore/category/1' }]
         }.to_json)
       stub_request(:get, "http://datastore/category/1").to_return(body: { name: 'Food' }.to_json)
       stub_request(:get, "http://datastore/category/2").to_return(body: { name: 'Drinks' }.to_json)

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -479,17 +479,29 @@ describe LHS::Record do
       stub_request(:get, "http://datastore/places/1")
         .to_return(body:{
           category_relations: [{
+            "href": "http://datastore/category/1"
+          }, {
             "href": "http://datastore/category/2"
           }]
         }.to_json)
-      stub_request(:get, "http://datastore/category/2")
+      stub_request(:get, "http://datastore/places/2")
+        .to_return(body:{
+          category_relations: [{
+            "href": "http://datastore/category/1"
+          }, {
+            "href": "http://datastore/category/2"
+          }]
+        }.to_json)
+      stub_request(:get, "http://datastore/category/1")
         .to_return(body: { name: 'Food' }.to_json)
+      stub_request(:get, "http://datastore/category/2")
+        .to_return(body: { name: 'Drinks' }.to_json)
     end
 
     it 'includes and merges linked resources in case of an array of links' do
       place = Place
         .includes(:category_relations)
-        .find(1)
+        .find(1, 2)
       expect(place.category_relations.first.name).to eq 'Food'
     end
   end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -469,4 +469,27 @@ describe LHS::Record do
       expect(place.contracts.to_a).to eq([])
     end
   end
+
+  context 'include and merge arrays' do
+
+    before(:each) do
+      class Place < LHS::Record
+        endpoint 'http://datastore/places/:id'
+      end
+      stub_request(:get, "http://datastore/places/1")
+        .to_return(body:{
+          category_relations: [{
+            "href": "http://datastore/categorie/2"
+          }]
+        }.to_json)
+      stub_request(:get, "http://datastore/categorie/2")
+        .to_return(body: { name: 'Food' }.to_json)
+    end
+
+    it 'includes and merges linked resources in case of an array of links' do
+      Place
+        .includes(:category_relations)
+        .find(1)
+    end
+  end
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -476,15 +476,7 @@ describe LHS::Record do
       class Place < LHS::Record
         endpoint 'http://datastore/places/:id'
       end
-      stub_request(:get, "http://datastore/places/1")
-        .to_return(body:{
-          category_relations: [{
-            "href": "http://datastore/category/1"
-          }, {
-            "href": "http://datastore/category/2"
-          }]
-        }.to_json)
-      stub_request(:get, "http://datastore/places/2")
+      stub_request(:get, %r(http://datastore/places/\d))
         .to_return(body:{
           category_relations: [{
             "href": "http://datastore/category/1"


### PR DESCRIPTION
*PATCH VERSION*

Including linked objects, when reference was an array of links was not working properly.
```ruby
# GET /place
{
  category_relations: [
    { href: 'http://datastore/category/1' }, { href: 'http://datastore/category/2' }
  ]
}
```

```ruby
Place
  .includes(:category_relations)
  .find(1, 2)
```