### PR TITLE
! includes/includes all with fancy/weird arrays

### DIFF
--- a/lib/lhs/complex.rb
+++ b/lib/lhs/complex.rb
@@ -30,7 +30,7 @@ class LHS::Complex
       merge_into_array!(other)
     elsif data.is_a?(Hash)
       merge_into_hash!(other)
-    else
+    elsif unwrap != other.unwrap
       raise ArgumentError, "Cannot merge #{unwrap} with #{other.unwrap}"
     end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -319,8 +319,8 @@ class LHS::Record
         data = LHC.request(options.compact).map do |response|
           LHS::Data.new(response.body, nil, self, response.request)
         end
-        including = LHS::Complex.reduce(options.compact.map{ |options| options.delete(:including) }.compact)
-        referencing = LHS::Complex.reduce(options.compact.map{ |options| options.delete(:referencing) }.compact)
+        including = LHS::Complex.reduce(options.compact.map { |options| options.delete(:including) }.compact)
+        referencing = LHS::Complex.reduce(options.compact.map { |options| options.delete(:referencing) }.compact)
         data = restore_with_nils(data, locate_nils(options)) # nil objects in data provide location information for mapping
         data = LHS::Data.new(data, nil, self)
         handle_includes(including, data, referencing) if including.present? && data.present?

--- a/spec/complex/reduce_spec.rb
+++ b/spec/complex/reduce_spec.rb
@@ -15,6 +15,12 @@ describe LHS::Complex do
     }.to raise_error(ArgumentError)
   end
 
+  it 'does not fail trying to merge primitive types when they are the same' do
+    expect {
+      LHS::Complex.reduce([{ entry: true }, { entry: true }])
+    }.not_to raise_error
+  end
+
   context 'first level' do
     context 'reduces symbols into/with X' do
       it 'reduces symbols into hash' do

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -132,10 +132,10 @@ describe LHS::Record do
 
         it 'includes_all in case of an empty array' do
           expect(
-            ->{ Contract.includes(:product).includes_all(:options).find(1) }
+            -> { Contract.includes(:product).includes_all(:options).find(1) }
           ).not_to raise_error
           expect(
-            ->{ Contract.includes(:product).includes_all(:options).find(1, 2) }
+            -> { Contract.includes(:product).includes_all(:options).find(1, 2) }
           ).not_to raise_error
         end
       end
@@ -150,10 +150,10 @@ describe LHS::Record do
 
         it 'includes_all in case of an unexpect objects within array' do
           expect(
-            ->{ Contract.includes(:product).includes_all(:options).find(1) }
+            -> { Contract.includes(:product).includes_all(:options).find(1) }
           ).not_to raise_error
           expect(
-            ->{ Contract.includes(:product).includes_all(:options).find(1, 2) }
+            -> { Contract.includes(:product).includes_all(:options).find(1, 2) }
           ).not_to raise_error
         end
       end

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -121,19 +121,36 @@ describe LHS::Record do
         class Contract < LHS::Record
           endpoint 'http://datastore/contracts/:id'
         end
-        stub_request(:get, "http://datastore/contracts/1")
+        stub_request(:get, %r{http://datastore/contracts/\d})
           .to_return(body: {
-            options: []
+            options: nested_resources
           }.to_json)
       end
 
-      it 'includes_all in case of an empty array' do
-        expect(lambda do
-          Contract
-            .includes(:product)
-            .includes_all(:options)
-            .find(1)
-        end).not_to raise_error
+      context 'empty array' do
+        let(:nested_resources) { [] }
+
+        it 'includes_all in case of an empty array' do
+          expect(
+            ->{ Contract.includes(:product).includes_all(:options).find(1) }
+          ).not_to raise_error
+          expect(
+            ->{ Contract.includes(:product).includes_all(:options).find(1, 2) }
+          ).not_to raise_error
+        end
+      end
+
+      context 'weird array without hrefs' do
+        let(:nested_resources) { [{ type: 'E_COMMERCE' }] }
+
+        it 'includes_all in case of an unexpect objects within array' do
+          expect(
+            ->{ Contract.includes(:product).includes_all(:options).find(1) }
+          ).not_to raise_error
+          expect(
+            ->{ Contract.includes(:product).includes_all(:options).find(1, 2) }
+          ).not_to raise_error
+        end
       end
     end
   end

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -141,7 +141,12 @@ describe LHS::Record do
       end
 
       context 'weird array without hrefs' do
-        let(:nested_resources) { [{ type: 'E_COMMERCE' }] }
+        before(:each) do
+          stub_request(:get, "http://datastore/options/1?limit=100")
+            .to_return(body: { type: 'REACH_EXT' }.to_json)
+        end
+
+        let(:nested_resources) { [{ href: 'http://datastore/options/1' }, { type: 'E_COMMERCE' }] }
 
         it 'includes_all in case of an unexpect objects within array' do
           expect(


### PR DESCRIPTION
*PATCH VERSION*

Including linked objects, when reference was an array partially with values and partially with hrefs, LHS failed.

```ruby
# GET /contracts
{
  options: [
    { href: 'http://datastore/option/1' },
    { type: 'E_COMMERCE' }
  ]
}
```

```ruby
Place
  .includes(:products)
  .includes_all(:options)
  .find(1)
```

Fixes a current problem in Customer Center:
https://rollbar.com/local.ch/ws-customer-center/items/1214/?item_page=0&#instances
https://rollbar.com/local.ch/ws-customer-center/items/1215/?item_page=0&#instances

### Now

LHS skips those items when including nested items.