### PR TITLE
Allow empty array responses

### DIFF
--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -17,7 +17,8 @@ class LHS::Collection < LHS::Proxy
   end
 
   def href
-    _data._raw[:href]
+    return _data._raw[:href] if _data.is_a? Hash
+    nil
   end
 
   def _collection

--- a/spec/collection/href_spec.rb
+++ b/spec/collection/href_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe LHS::Collection do
+  let(:collection) do
+    LHS::Collection.new(LHS::Data.new([]))
+  end
+
+  context 'array misses href' do
+    it 'works with empty array' do
+      expect(
+        collection.href
+      ).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
When querying with `where` and the server responds with `[]`, there is no `href` to use as an ID. This is a work-around for that case.