### PR TITLE
Record.where(color: 'blue').expanded

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ If you want to have LHS expand those items, use `expanded` as part of a Query-Ch
 ```json
   { 
     "items" : [
-      { "href" : "http://local.ch/customer/1/accounts/1" },
-      { "href": "http://local.ch/customer/1/accounts/2" },
-      { "href": "http://local.ch/customer/1/accounts/3" }
+      {"href": "http://local.ch/customer/1/accounts/1"},
+      {"href": "http://local.ch/customer/1/accounts/2"},
+      {"href": "http://local.ch/customer/1/accounts/3"}
     ] 
   }
 end

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ end
   Account.where(customer_id: 123).expanded
 ```
 
-You can also apply options to expand in order to apply anything on the requests made to expand the links:
+You can also apply options to `expanded` in order to apply anything on the requests made to expand the links:
 
 ```ruby
   Account.where(customer_id: 123).expanded(auth: { bearer: access_token })

--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ If you want to have LHS expand those items, use `expanded` as part of a Query-Ch
 
 ```json
   { 
-    items: [
-      { href: 'http://local.ch/customer/1/accounts/1' },
-      { href: 'http://local.ch/customer/1/accounts/2' },
-      { href: 'http://local.ch/customer/1/accounts/3' }
+    "items" : [
+      { "href" : "http://local.ch/customer/1/accounts/1" },
+      { "href": "http://local.ch/customer/1/accounts/2" },
+      { "href": "http://local.ch/customer/1/accounts/3" }
     ] 
   }
 end

--- a/README.md
+++ b/README.md
@@ -71,6 +71,31 @@ This uses the `:service/v2/records` endpoint, cause `:association_id` was not pr
 
 Uses the `:service/v2/association/:association_id/records` endpoint.
 
+### Expand plain collection of links
+
+Some endpoints could respond a plain list of links without any expanded data. Like search endpoints.
+If you want to have LHS expand those items, use `expanded` as part of a Query-Chain:
+
+```json
+  { 
+    items: [
+      { href: 'http://local.ch/customer/1/accounts/1' },
+      { href: 'http://local.ch/customer/1/accounts/2' },
+      { href: 'http://local.ch/customer/1/accounts/3' }
+    ] 
+  }
+end
+
+```ruby
+  Account.where(customer_id: 123).expanded
+```
+
+You can also apply options to expand in order to apply anything on the requests made to expand the links:
+
+```ruby
+  Account.where(customer_id: 123).expanded(auth: { bearer: access_token })
+```
+
 ## Chaining where statements
 
 LHS supports chaining where statements. 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ If you want to have LHS expand those items, use `expanded` as part of a Query-Ch
     ] 
   }
 end
+```
 
 ```ruby
   Account.where(customer_id: 123).expanded

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -21,6 +21,10 @@ class LHS::Record
         chain
       end
 
+      def expanded(options = nil)
+        Chain.new(self, Option.new(expanded: options || true))
+      end
+
       def options(hash = nil)
         Chain.new(self, Option.new(hash))
       end
@@ -179,6 +183,10 @@ class LHS::Record
 
       def all(hash = nil)
         push([Parameter.new(hash), Option.new(all: true)])
+      end
+
+      def expanded(options = nil)
+        push(Option.new(expanded: options || true))
       end
 
       def options(hash = nil)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -428,8 +428,9 @@ class LHS::Record
       end
 
       def expand_items(data, expand_options)
+        expand_options = {} unless expand_options.is_a?(Hash)
         options = data.map do |item|
-          (expand_options || {}).merge(url: item.href)
+          expand_options.merge(url: item.href)
         end
         expanded_data = request(options)
         data.each_with_index do |item, index|

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -422,8 +422,19 @@ class LHS::Record
         response = LHC.request(process_options(options, endpoint))
         data = LHS::Data.new(response.body, nil, self, response.request, endpoint)
         load_and_merge_remaining_objects!(data, process_options(options, endpoint)) if paginated?(data._raw) && options[:all]
+        expand_items(data, options[:expanded]) if data.collection? && options[:expanded]
         handle_includes(including, data, referencing) if including.present? && data.present?
         data
+      end
+
+      def expand_items(data, expand_options)
+        options = data.map do |item|
+          (expand_options || {}).merge(url: item.href)
+        end
+        expanded_data = request(options)
+        data.each_with_index do |item, index|
+          item.merge_raw!(expanded_data[index])
+        end
       end
 
       def url_option_for(item, key = nil)

--- a/spec/record/expanded_spec.rb
+++ b/spec/record/expanded_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://local.ch/v2/records'
+    end
+  end
+
+  let!(:request_collection) do
+    stub_request(:get, "http://local.ch/v2/records?color=blue")
+      .to_return(body: {
+        items: [
+          { href: 'http://local.ch/v2/records/1' },
+          { href: 'http://local.ch/v2/records/2' }
+        ]
+      }.to_json)
+  end
+
+  let!(:request_item_1) do
+    stub_request(:get, "http://local.ch/v2/records/1?via=collection")
+      .to_return(body: {
+        name: 'Steve'
+      }.to_json)
+  end
+
+  let!(:request_item_2) do
+    stub_request(:get, "http://local.ch/v2/records/2?via=collection")
+      .to_return(body: {
+        name: 'John'
+      }.to_json)
+  end
+
+  it 'expands collections that just contains links' do
+    records = Record.where(color: 'blue').expanded(params: { via: 'collection' })
+    expect(records[0].name).to eq 'Steve'
+    expect(records[1].name).to eq 'John'
+    assert_requested request_collection
+    assert_requested request_item_1
+    assert_requested request_item_2
+  end
+end

--- a/spec/record/expanded_spec.rb
+++ b/spec/record/expanded_spec.rb
@@ -39,4 +39,30 @@ describe LHS::Record do
     assert_requested request_item_1
     assert_requested request_item_2
   end
+
+  context 'without options' do
+
+    let!(:request_item_1) do
+      stub_request(:get, "http://local.ch/v2/records/1")
+        .to_return(body: {
+          name: 'Steve'
+        }.to_json)
+    end
+
+    let!(:request_item_2) do
+      stub_request(:get, "http://local.ch/v2/records/2")
+        .to_return(body: {
+          name: 'John'
+        }.to_json)
+    end
+
+    it 'works also without options' do
+      records = Record.where(color: 'blue').expanded
+      expect(records[0].name).to eq 'Steve'
+      expect(records[1].name).to eq 'John'
+      assert_requested request_collection
+      assert_requested request_item_1
+      assert_requested request_item_2
+    end
+  end
 end

--- a/spec/record/expanded_spec.rb
+++ b/spec/record/expanded_spec.rb
@@ -41,7 +41,6 @@ describe LHS::Record do
   end
 
   context 'without options' do
-
     let!(:request_item_1) do
       stub_request(:get, "http://local.ch/v2/records/1")
         .to_return(body: {


### PR DESCRIPTION
### Expand plain collection of links

Some endpoints could respond a plain list of links without any expanded data. Like search endpoints.
If you want to have LHS expand those items, use `expanded` as part of a Query-Chain:

```json
  { 
    "items" : [
      { "href" : "http://local.ch/customer/1/accounts/1" },
      { "href": "http://local.ch/customer/1/accounts/2" },
      { "href": "http://local.ch/customer/1/accounts/3" }
    ] 
  }
end
```

```ruby
  Account.where(customer_id: 123).expanded
```

You can also apply options to `expanded` in order to apply anything on the requests made to expand the links:

```ruby
  Account.where(customer_id: 123).expanded(auth: { bearer: access_token })
```