### PR TITLE
Compatibility with ActiveModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ In case you want to add custom validation errors to an instance of LHS::Record:
 
 ```ruby
 user.errors.add(:name, 'The name you provided is not valid.')
-```.
+```
 
 ### Know issue with `ActiveModel::Validations`
 If you are using `ActiveModel::Validations` and add errors to the LHS::Record instance - as described above - then those errors will be overwritten by the errors from `ActiveModel::Validations` when using `save`  or `valid?`. [Open issue](https://github.com/local-ch/lhs/issues/159)

--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ The parameters passed to the `validates` endpoint option are used to perform the
 
 ### Reset validation errors
 
-Clear the error messages. Compatible to [ActiveRecord](https://github.com/rails/rails/blob/6c8cf21584ced73ade45529d11463c74b5a0c58f/activemodel/lib/active_model/errors.rb#L85).
+Clear the error messages. Compatible with [ActiveRecord](https://github.com/rails/rails/blob/6c8cf21584ced73ade45529d11463c74b5a0c58f/activemodel/lib/active_model/errors.rb#L85).
 
 ```ruby
 record.errors.clear

--- a/README.md
+++ b/README.md
@@ -309,15 +309,7 @@ end
   )
 ```
 
-When creation fails, the object contains errors. It provides them through the `errors` attribute:
-
-```ruby
-  record.errors #<LHS::Errors>
-  record.errors.include?(:ratings) # true
-  record.errors[:ratings] # ['REQUIRED_PROPERTY_VALUE']
-  record.errors.messages # {:ratings=>["REQUIRED_PROPERTY_VALUE"], :recommended=>["REQUIRED_PROPERTY_VALUE"]}
-  record.errors.message # ratings must be set when review or name or review_title is set | The property value is required; it cannot be null, empty, or blank."
-```
+See [Validation](#Validation) for handling validation errors when creating records.
 
 ## Create records through associations (nested resources)
 
@@ -680,6 +672,12 @@ user = User.build(email: 'im not an email address')
 unless user.valid?
   fail(user.errors[:email])
 end
+
+user.errors #<LHS::Errors>
+user.errors.include?(:email) # true
+user.errors[:email] # ['REQUIRED_PROPERTY_VALUE']
+user.errors.messages # {:email=>["REQUIRED_PROPERTY_VALUE"]}
+user.errors.message # email must be set when user is created."
 ```
 
 The parameters passed to the `validates` endpoint option are used to perform the validation:
@@ -691,13 +689,21 @@ The parameters passed to the `validates` endpoint option are used to perform the
   endpoint ':service/v2/users', validates: { path: 'validate' }            # will perform a validation via :service/v2/users/validate
 ```
 
-## Custom validation errors
+### Reset validation errors
+
+Clear the error messages. Compatible to [ActiveRecord](https://github.com/rails/rails/blob/6c8cf21584ced73ade45529d11463c74b5a0c58f/activemodel/lib/active_model/errors.rb#L85).
+
+```ruby
+record.errors.clear
+```
+
+### Custom validation errors
 
 In case you want to add custom validation errors to an instance of LHS::Record:
 
 ```ruby
 user.errors.add(:name, 'The name you provided is not valid.')
-```
+```.
 
 ### Know issue with `ActiveModel::Validations`
 If you are using `ActiveModel::Validations` and add errors to the LHS::Record instance - as described above - then those errors will be overwritten by the errors from `ActiveModel::Validations` when using `save`  or `valid?`. [Open issue](https://github.com/local-ch/lhs/issues/159)

--- a/lib/lhs/concerns/item/validation.rb
+++ b/lib/lhs/concerns/item/validation.rb
@@ -7,7 +7,7 @@ class LHS::Item < LHS::Proxy
 
     def valid?(options = {})
       options ||= {}
-      self.errors.clear
+      errors.clear
       endpoint = validation_endpoint
       raise 'No endpoint found to perform validations! See here: https://github.com/local-ch/lhs#validation' unless endpoint
       record = LHS::Record.for_url(endpoint.url)

--- a/lib/lhs/concerns/item/validation.rb
+++ b/lib/lhs/concerns/item/validation.rb
@@ -7,7 +7,7 @@ class LHS::Item < LHS::Proxy
 
     def valid?(options = {})
       options ||= {}
-      self.errors = nil
+      self.errors.clear
       endpoint = validation_endpoint
       raise 'No endpoint found to perform validations! See here: https://github.com/local-ch/lhs#validation' unless endpoint
       record = LHS::Record.for_url(endpoint.url)

--- a/lib/lhs/errors.rb
+++ b/lib/lhs/errors.rb
@@ -53,6 +53,11 @@ class LHS::Errors
     values.flatten.size
   end
 
+  def clear
+    @raw = nil
+    @messages.clear
+  end
+
   delegate :values, to: :messages
 
   delegate :keys, to: :messages

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -157,4 +157,20 @@ describe LHS::Item do
       expect(record.errors['body']).to eq ['parse error']
     end
   end
+
+  describe '#clear' do
+    let(:record) { Record.build(name: 'Steve') }
+
+    before(:each) do
+      stub_request(:post, "#{datastore}/feedbacks")
+        .to_return(status: 400, body: error_format_fields.to_json)
+    end
+
+    it 'resets all errors' do
+      record.save
+      expect(record.errors.any?).to eq true
+      record.errors.clear
+      expect(record.errors.any?).to eq false
+    end
+  end
 end

--- a/spec/item/validation_spec.rb
+++ b/spec/item/validation_spec.rb
@@ -95,7 +95,6 @@ describe LHS::Item do
       expect(user.valid?).to eq true
       expect(user.errors.messages).to be_empty
     end
-
   end
 
   context 'endpoint does not support validations' do

--- a/spec/item/validation_spec.rb
+++ b/spec/item/validation_spec.rb
@@ -93,8 +93,9 @@ describe LHS::Item do
       user.email = 'steve@local.ch'
       successful_validation
       expect(user.valid?).to eq true
-      expect(user.errors).to be_nil
+      expect(user.errors.messages).to be_empty
     end
+
   end
 
   context 'endpoint does not support validations' do


### PR DESCRIPTION
Compatibility with ActiveModel

ActiveModel expects the errors object to always be present
!~ Introduce 'clear' on LHS::Error to mimic ActiveModel::Error behaviour