### PR TITLE
Add missing seconds to regex for datetime detection

### DIFF
--- a/.rubocop.localch.yml
+++ b/.rubocop.localch.yml
@@ -16,10 +16,11 @@ AllCops:
     - 'config/unicorn.rb'
     - 'config/compass.rb'
     - 'Rakefile'
+    - 'Gemfile'
 
 Rails:
   Enabled: true
-  
+
 Lint/HandleExceptions:
   Exclude:
     - spec/**/*

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
   s.add_development_dependency 'capybara'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 0.47.0'
   s.add_development_dependency 'json', '>=  1.8.2'
 
   s.license = 'GPL-3'

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -68,7 +68,7 @@ class LHS::Proxy
     end
 
     def date_time_regex
-      /(?<date>\d{4}-\d{2}-\d{2})?(?<time>T\d{2}:\d{2}:\d{2}(\.\d*.\d{2}:\d{2})*)?/
+      /(?<date>\d{4}-\d{2}-\d{2})?(?<time>T\d{2}:\d{2}(:\d{2}(\.\d*.\d{2}:\d{2})*)?)?/
     end
   end
 end

--- a/spec/data/item_spec.rb
+++ b/spec/data/item_spec.rb
@@ -41,14 +41,64 @@ describe LHS::Data do
   end
 
   context 'different date time formats' do
-    let(:item) do
-      item = data[0]
-      item._raw[:created_date] = '2016-07-09T13:45:00+00:00'
-      item
+    context 'with numbered time zone' do
+      let(:item) do
+        item = data[0]
+        item._raw[:created_date] = '2016-07-09T13:45:00+02:00'
+        item
+      end
+
+      it 'returns TimeWithZone if string can be parsed as date_time' do
+        expect(item.created_date).to be_kind_of ActiveSupport::TimeWithZone
+      end
+
+      it 'has UTC time zone' do
+        expect(item.created_date.zone).to eq('UTC')
+      end
+
+      it 'has the right time' do
+        expect(item.created_date.hour).to eq(11)
+      end
     end
 
-    it 'returns TimeWithZone if string can be parsed as date_time' do
-      expect(item.created_date).to be_kind_of ActiveSupport::TimeWithZone
+    context 'with lettered time zone' do
+      let(:item) do
+        item = data[0]
+        item._raw[:created_date] = '2016-07-09T13:45:00Z'
+        item
+      end
+
+      it 'returns TimeWithZone if string can be parsed as date_time' do
+        expect(item.created_date).to be_kind_of ActiveSupport::TimeWithZone
+      end
+
+      it 'has UTC time zone' do
+        expect(item.created_date.zone).to eq('UTC')
+      end
+
+      it 'has the right time' do
+        expect(item.created_date.hour).to eq(13)
+      end
+    end
+
+    context 'without seconds' do
+      let(:item) do
+        item = data[0]
+        item._raw[:created_date] = '2016-07-09T13:45Z'
+        item
+      end
+
+      it 'returns TimeWithZone if string can be parsed as date_time' do
+        expect(item.created_date).to be_kind_of ActiveSupport::TimeWithZone
+      end
+
+      it 'has UTC time zone' do
+        expect(item.created_date.zone).to eq('UTC')
+      end
+
+      it 'has the right time' do
+        expect(item.created_date.hour).to eq(13)
+      end
     end
   end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets  = true
-  config.static_cache_control = 'public, max-age=3600'
+  config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_assets        = true
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets        = true
+  config.public_file_server.enabled = true
   config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
 
   # Show full error reports and disable caching.


### PR DESCRIPTION
Java backends omit the seconds on ISO8601 times if they're `00`. The RegEx used to detect if it's a `Date` or `DateTime` did not take that into account and has been fixed.