### PR TITLE
Consider records with an empty href not persisted

### DIFF
--- a/lib/lhs/concerns/record/model.rb
+++ b/lib/lhs/concerns/record/model.rb
@@ -11,7 +11,7 @@ class LHS::Record
     end
 
     def persisted?
-      !href.nil?
+      !href.blank?
     end
 
     included do

--- a/spec/record/persisted_spec.rb
+++ b/spec/record/persisted_spec.rb
@@ -12,7 +12,7 @@ describe LHS::Record do
     end
 
     context 'for new record' do
-      subject { Feedback.new }
+      subject { Feedback.new(href: '') }
 
       it 'is false' do
         expect(subject.persisted?).to be(false)

--- a/spec/record/persisted_spec.rb
+++ b/spec/record/persisted_spec.rb
@@ -12,10 +12,20 @@ describe LHS::Record do
     end
 
     context 'for new record' do
-      subject { Feedback.new(href: '') }
+      context 'with a nil href' do
+        subject { Feedback.new }
 
-      it 'is false' do
-        expect(subject.persisted?).to be(false)
+        it 'is false' do
+          expect(subject.persisted?).to be(false)
+        end
+      end
+
+      context 'with an empty href' do
+        subject { Feedback.new(href: '') }
+
+        it 'is false' do
+          expect(subject.persisted?).to be(false)
+        end
       end
     end
 


### PR DESCRIPTION
*Patch version*

If the `href` attribute comes from a rails form, it will be `""` (an empty string) instead of nil. In that case, the record is still not persisted.