### PR TITLE
Fix identifying records

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.0.0'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'lhc', '>= 5.0.2'
+  s.add_dependency 'lhc', '>= 5.0.3'
   s.add_dependency 'activesupport', '> 4.2'
 
   s.add_development_dependency 'rspec-rails', '>= 3.0.0'

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -24,11 +24,9 @@ class LHS::Proxy
       end
 
       record = LHS::Record.for_url(value[:href]) if value.is_a?(Hash) && value[:href]
-      if accessing_item?(value, record)
-        return access_item(value, record)
-      elsif accessing_collection?(value, record)
-        return access_collection(value, record)
-      end
+      
+      access_item(value, record) ||
+      access_collection(value, record) ||
       convert(value)
     end
 
@@ -57,22 +55,21 @@ class LHS::Proxy
     end
 
     def access_item(value, record)
-      data = LHS::Data.new(value, _data)
-      if record
-        record.new(data)
-      else
-        data
-      end
+      return unless accessing_item?(value, record)
+      wrap_return(value, record)
     end
 
     def access_collection(value, record)
+      return unless accessing_collection?(value, record)
+      collection_data = LHS::Data.new(value, _data)
+      collection = LHS::Collection.new(collection_data)
+      wrap_return(collection, record)
+    end
+
+    def wrap_return(value, record)
       data = LHS::Data.new(value, _data)
-      collection = LHS::Collection.new(data)
-      if record
-        record.new(collection)
-      else
-        LHS::Data.new(collection, _data)
-      end
+      return record.new(data) if record
+      data
     end
 
     def date?(value)

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -24,10 +24,10 @@ class LHS::Proxy
       end
 
       record = LHS::Record.for_url(value[:href]) if value.is_a?(Hash) && value[:href]
-      
+
       access_item(value, record) ||
-      access_collection(value, record) ||
-      convert(value)
+        access_collection(value, record) ||
+        convert(value)
     end
 
     def accessing_item?(value, record)

--- a/lib/lhs/concerns/record/configuration.rb
+++ b/lib/lhs/concerns/record/configuration.rb
@@ -7,6 +7,8 @@ class LHS::Record
   module Configuration
     extend ActiveSupport::Concern
 
+    DEFAULT_ITEMS_KEY = :items
+
     mattr_accessor :configuration
 
     module ClassMethods
@@ -15,7 +17,7 @@ class LHS::Record
       end
 
       def items_key
-        (@configuration.try(:[], :items_key) || :items).to_sym
+        (@configuration.try(:[], :items_key) || DEFAULT_ITEMS_KEY).to_sym
       end
 
       def limit_key

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -49,9 +49,20 @@ class LHS::Record
         endpoint = LHS::Endpoint.for_url(url)
         return unless endpoint
         template = endpoint.url
-        new_options = options.deep_merge(params: LHC::Endpoint.values_as_params(template, url))
+        new_options = options.deep_merge(
+          params: LHC::Endpoint.values_as_params(template, url).merge(values_from_get_params(url))
+        )
         new_options[:url] = template
         new_options
+      end
+
+      # Extracts values from url's get parameters
+      # and return them as a ruby hash
+      def values_from_get_params(url)
+        uri = URI.parse(url)
+        return {} unless uri.query.present?
+        params = Rack::Utils.parse_nested_query(uri.query)
+        params
       end
 
       # Extends existing raw data with additionaly fetched data

--- a/spec/proxy/record_identification_spec.rb
+++ b/spec/proxy/record_identification_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe LHS::Proxy do
-  
   before(:each) do
     class Search < LHS::Record
       endpoint 'http://search/results', items_key: :docs
@@ -13,7 +12,6 @@ describe LHS::Proxy do
   end
 
   context 'identifying records' do
-
     it 'identifies records correctly even if parent record has another configuration set' do
       stub_request(:get, "http://search/results?what=Blumen")
         .to_return(body: {
@@ -25,7 +23,7 @@ describe LHS::Proxy do
         }.to_json)
       stub_request(:get, "http://datastore/places/1/feedbacks?limit=10&offset=0")
         .to_return(body: {
-          items: [{review: 'Nice restaurant'}]
+          items: [{ review: 'Nice restaurant' }]
         }.to_json)
       result = Search.where(what: 'Blumen').includes(place: :feedbacks)
       expect(result.place.feedbacks).to be_kind_of Feedback

--- a/spec/proxy/record_identification_spec.rb
+++ b/spec/proxy/record_identification_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe LHS::Proxy do
+  
+  before(:each) do
+    class Search < LHS::Record
+      endpoint 'http://search/results', items_key: :docs
+    end
+
+    class Feedback < LHS::Record
+      endpoint 'http://datastore/places/:place_id/feedbacks'
+    end
+  end
+
+  context 'identifying records' do
+
+    it 'identifies records correctly even if parent record has another configuration set' do
+      stub_request(:get, "http://search/results?what=Blumen")
+        .to_return(body: {
+          place: { href: 'http://datastore/places/1' }
+        }.to_json)
+      stub_request(:get, "http://datastore/places/1")
+        .to_return(body: {
+          feedbacks: { href: 'http://datastore/places/1/feedbacks?limit=10&offset=0' }
+        }.to_json)
+      stub_request(:get, "http://datastore/places/1/feedbacks?limit=10&offset=0")
+        .to_return(body: {
+          items: [{review: 'Nice restaurant'}]
+        }.to_json)
+      result = Search.where(what: 'Blumen').includes(place: :feedbacks)
+      expect(result.place.feedbacks).to be_kind_of Feedback
+      expect(result.place.feedbacks.first.review).to eq 'Nice restaurant'
+    end
+  end
+end


### PR DESCRIPTION
*PATCH VERSION*

This change fixes three issues. All three in combination lead to the problem, that a nested data collection was not recognized as such, as mentioned in https://github.com/local-ch/lhs/issues/215

(1) When accessing data, items/collections only have been distinguished by being either a hash or an array. I fixed/improved that, so that also hashes with an `items_key` get recognized as a collection when accessed.

(2) When a nested resource is linked, and this link contained get parameters, those get parameters have been dropped as part of making the link dynamically overloadable or parameters of the url , according to defined endpoint templates, exchangeable. Those preset get-paramters are now kept/preserved.

(3) When accessing a collection, the returned data does not have been wrapped in an identified record. As LHS always applies configuration from parent records, accessing collections e.g. via configured parents, had LHS apply the parents configuration also on the nested data.

Example:
```
{
  docs: [
    place: { 
      href: 'http://local.ch/places/1',
      feedbacks: {
        href: 'http://local.ch/places/1/feedbacks',
        items: [{ review: 'great food' }]
      }
    }
  ]
}
```

As the parent record was configured to access collections via  `docs` it also has tried to identify the feedbacks collection by this key.