### PR TITLE
Validation errors translated by convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,8 +777,8 @@ Just like Activerecord, LHS tries to translate validation error messages.
 If a translation exists for one of the following translation keys, LHS will take a translated error (also in the following order) rather than the plain error message/code:
 
 ```ruby
-lhs.errors.records.customers.attributes.name.unsupported_property_value
-lhs.errors.records.customers.unsupported_property_value
+lhs.errors.records.customer.attributes.name.unsupported_property_value
+lhs.errors.records.customer.unsupported_property_value
 lhs.errors.messages.unsupported_property_value
 lhs.errors.attributes.name.unsupported_property_value
 lhs.errors.fallback_message

--- a/README.md
+++ b/README.md
@@ -771,6 +771,19 @@ You can also access those nested errors like:
 @customer.address.street.errors
 ```
 
+### Translation of validation errors
+
+Just like Activerecord, LHS tries to translate validation error messages.
+If a translation exists for one of the following translation keys, LHS will take a translated error (also in the following order) rather than the plain error message/code:
+
+```ruby
+lhs.errors.records.customers.attributes.name.unsupported_property_value
+lhs.errors.records.customers.unsupported_property_value
+lhs.errors.messages.unsupported_property_value
+lhs.errors.attributes.name.unsupported_property_value
+lhs.errors.fallback_message
+```
+
 ### Know issue with `ActiveModel::Validations`
 If you are using `ActiveModel::Validations` and add errors to the LHS::Record instance - as described above - then those errors will be overwritten by the errors from `ActiveModel::Validations` when using `save`  or `valid?`. [Open issue](https://github.com/local-ch/lhs/issues/159)
 

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -20,7 +20,7 @@ class LHS::Item < LHS::Proxy
         apply_default_creation_options(options, url, data)
       )
     rescue LHC::Error => e
-      self.errors = LHS::Errors::Base.new(e.response)
+      self.errors = LHS::Errors::Base.new(e.response, record)
       raise e
     end
 
@@ -34,19 +34,18 @@ class LHS::Item < LHS::Proxy
     end
 
     def create_and_merge_data!(options)
-      direct_response_data = record_for_persistance.request(options)
+      direct_response_data = record.request(options)
       _data.merge_raw!(direct_response_data)
       response_headers = direct_response_data._request.response.headers
       if response_headers && response_headers['Location']
-        location_data = record_for_persistance.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
+        location_data = record.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
         _data.merge_raw!(location_data)
       end
       true
     end
 
     def endpoint_for_persistance(data, options)
-      record_for_persistance
-        .find_endpoint(merge_data_with_options(data, options))
+      record.find_endpoint(merge_data_with_options(data, options))
     end
 
     def merge_data_with_options(data, options)
@@ -55,10 +54,6 @@ class LHS::Item < LHS::Proxy
       else
         data
       end
-    end
-
-    def record_for_persistance
-      _data.class
     end
 
     def url_for_persistance!(options, data)

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -9,14 +9,14 @@ class LHS::Item < LHS::Proxy
     def update(params, options = nil)
       update!(params, options)
     rescue LHC::Error => e
-      self.errors = LHS::Errors::Base.new(e.response)
+      self.errors = LHS::Errors::Base.new(e.response, record)
       false
     end
 
     def update!(params, options = {})
       options ||= {}
-      _data.merge_raw!(LHS::Data.new(params, _data.parent, _data.class))
-      response_data = _data.class.request(
+      _data.merge_raw!(LHS::Data.new(params, _data.parent, record))
+      response_data = record.request(
         options.merge(
           method: :post,
           url: href,

--- a/lib/lhs/concerns/item/validation.rb
+++ b/lib/lhs/concerns/item/validation.rb
@@ -16,7 +16,7 @@ class LHS::Item < LHS::Proxy
       run_validation!(record, options, url, params)
       true
     rescue LHC::Error => e
-      self.errors = LHS::Errors::Base.new(e.response)
+      self.errors = LHS::Errors::Base.new(e.response, record)
       false
     end
     alias validate valid?
@@ -51,7 +51,7 @@ class LHS::Item < LHS::Proxy
 
     def validation_endpoint
       endpoint = endpoint_from_link if _data.href # take embeded first
-      endpoint ||= _data._record.find_endpoint(_data._raw)
+      endpoint ||= record.find_endpoint(_data._raw)
       validates = endpoint.options && endpoint.options.fetch(:validates, false)
       raise 'Endpoint does not support validations!' unless validates
       endpoint

--- a/lib/lhs/concerns/proxy/errors.rb
+++ b/lib/lhs/concerns/proxy/errors.rb
@@ -11,11 +11,11 @@ class LHS::Proxy
 
     def initialize(data)
       super(data)
-      self.errors = LHS::Errors::Base.new
+      self.errors = LHS::Errors::Base.new(nil, record)
     end
 
     def errors
-      @errors ||= LHS::Errors::Base.new
+      @errors ||= LHS::Errors::Base.new(nil, record)
     end
   end
 end

--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -81,19 +81,23 @@ module LHS::Errors
     end
 
     def generate_message(attribute, message, _options = {})
+      find_translated_error_message(attribute, message) || message
+    end
+
+    def find_translated_error_message(attribute, message)
       record_name = record.model_name.name.underscore
-      normalize_attribute = attribute.to_s.underscore
+      normalized_attribute = attribute.to_s.underscore
       normalized_message = message.to_s.underscore
       [
-        ['lhs', 'errors', 'records', record_name, 'attributes', normalize_attribute, normalized_message],
+        ['lhs', 'errors', 'records', record_name, 'attributes', normalized_attribute, normalized_message],
         ['lhs', 'errors', 'records', record_name, normalized_message],
         ['lhs', 'errors', 'messages', normalized_message],
-        ['lhs', 'errors', 'attributes', normalize_attribute, normalized_message],
+        ['lhs', 'errors', 'attributes', normalized_attribute, normalized_message],
         ['lhs', 'errors', 'fallback_message']
       ].detect do |path|
         key = path.join('.')
         return I18n.translate(key) if I18n.exists?(key)
-      end || message
+      end
     end
 
     def parse_messages(json)

--- a/lib/lhs/proxy.rb
+++ b/lib/lhs/proxy.rb
@@ -16,6 +16,10 @@ class LHS::Proxy
     self._loaded = false
   end
 
+  def record
+    _data.class
+  end
+
   def load!(options = nil)
     return self if _loaded
     reload!(options)

--- a/spec/item/translate_errors_spec.rb
+++ b/spec/item/translate_errors_spec.rb
@@ -1,0 +1,197 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://dataste/records'
+    end
+
+    stub_request(:post, "http://dataste/records")
+      .to_return(
+        status: 400,
+        body: {
+          field_errors: [{
+            "code" => "UNSUPPORTED_PROPERTY_VALUE",
+            "path" => ["name"]
+          }]
+        }.to_json
+      )
+
+    I18n.reload!
+    I18n.backend.store_translations(:en, YAML.safe_load(translation)) if translation.present?
+  end
+
+  let(:errors) { Record.create(name: 'Steve').errors }
+
+  context 'detailed error translation for record and attribute' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            records:
+              record:
+                attributes:
+                  name:
+                    unsupported_property_value: 'This value is not supported'
+      }
+    end
+
+    it 'translates errors automatically when they are around' do
+      expect(errors[:name]).to eq ['This value is not supported']
+    end
+  end
+
+  context 'error translation for record' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            records:
+              record:
+                unsupported_property_value: 'This value is unfortunately not supported'
+      }
+    end
+
+    it 'translates errors automatically when they are around' do
+      expect(errors[:name]).to eq ['This value is unfortunately not supported']
+    end
+  end
+
+  context 'error translation for message' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            messages:
+              unsupported_property_value: 'This value is sadly not supported'
+      }
+    end
+
+    it 'translates errors automatically when they are around' do
+      expect(errors[:name]).to eq ['This value is sadly not supported']
+    end
+  end
+
+  context 'error translation for attributes' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            attributes:
+              name:
+                unsupported_property_value: 'This value is not supported – bummer'
+      }
+    end
+
+    it 'translates errors automatically when they are around' do
+      expect(errors[:name]).to eq ['This value is not supported – bummer']
+    end
+  end
+
+  context 'error translation for fallback message' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            fallback_message: 'This value is wrong'
+      }
+    end
+
+    it 'translates errors automatically when they are around' do
+      expect(errors[:name]).to eq ['This value is wrong']
+    end
+  end
+
+  context 'detailed record attribute over other translations' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            fallback_message: 'This value is wrong'
+            attributes:
+              name:
+                unsupported_property_value: 'This value is not supported – bummer'
+            messages:
+              unsupported_property_value: 'This value is sadly not supported'
+            records:
+              record:
+                unsupported_property_value: 'This value is unfortunately not supported'
+                attributes:
+                  name:
+                    unsupported_property_value: 'This value is not supported'
+      }
+    end
+
+    it 'takes detailed record attribute over other translations' do
+      expect(errors[:name]).to eq ['This value is not supported']
+    end
+  end
+
+  context 'record translations over global messages, attributes and fallback' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            fallback_message: 'This value is wrong'
+            attributes:
+              name:
+                unsupported_property_value: 'This value is not supported – bummer'
+            messages:
+              unsupported_property_value: 'This value is sadly not supported'
+            records:
+              record:
+                unsupported_property_value: 'This value is unfortunately not supported'
+      }
+    end
+
+    it 'takes detailed record attribute over other translations' do
+      expect(errors[:name]).to eq ['This value is unfortunately not supported']
+    end
+  end
+
+  context 'global message translation over attributes and fallback' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            fallback_message: 'This value is wrong'
+            attributes:
+              name:
+                unsupported_property_value: 'This value is not supported – bummer'
+            messages:
+              unsupported_property_value: 'This value is sadly not supported'
+      }
+    end
+
+    it 'takes detailed record attribute over other translations' do
+      expect(errors[:name]).to eq ['This value is sadly not supported']
+    end
+  end
+
+  context 'global attributes over fallback' do
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            fallback_message: 'This value is wrong'
+            attributes:
+              name:
+                unsupported_property_value: 'This value is not supported – bummer'
+      }
+    end
+
+    it 'takes detailed record attribute over other translations' do
+      expect(errors[:name]).to eq ['This value is not supported – bummer']
+    end
+  end
+
+  context 'no translation' do
+    let(:translation) do
+      %q{}
+    end
+
+    it 'takes no translation but keeps on storing the error message/code' do
+      expect(errors[:name]).to eq ['UNSUPPORTED_PROPERTY_VALUE']
+    end
+  end
+end


### PR DESCRIPTION
*Minor Version*

### Translation of validation errors

Just like Activerecord, LHS tries to translate validation error messages.
If a translation exists for one of the following translation keys, LHS will take a translated error (also in the following order) rather than the plain error message/code:

```ruby
lhs.errors.records.customers.attributes.name.unsupported_property_value
lhs.errors.records.customers.unsupported_property_value
lhs.errors.messages.unsupported_property_value
lhs.errors.attributes.name.unsupported_property_value
lhs.errors.fallback_message
```
