### PR TITLE
Fix: There is no record for nested unknown data types

### DIFF
--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -85,19 +85,26 @@ module LHS::Errors
     end
 
     def find_translated_error_message(attribute, message)
-      record_name = record ? record.model_name.name.underscore : nil
       normalized_attribute = attribute.to_s.underscore
       normalized_message = message.to_s.underscore
-      [
-        record_name ? ['lhs', 'errors', 'records', record_name, 'attributes', normalized_attribute, normalized_message] : nil,
-        record_name ? ['lhs', 'errors', 'records', record_name, normalized_message] : nil,
+      messages = []
+      messages = messages_for_record(normalized_attribute, normalized_message) if record
+      messages.concat([
         ['lhs', 'errors', 'messages', normalized_message],
         ['lhs', 'errors', 'attributes', normalized_attribute, normalized_message],
         ['lhs', 'errors', 'fallback_message']
-      ].compact.detect do |path|
+      ]).detect do |path|
         key = path.join('.')
         return I18n.translate(key) if I18n.exists?(key)
       end
+    end
+
+    def messages_for_record(normalized_attribute, normalized_message)
+      record_name = record.model_name.name.underscore
+      [
+        ['lhs', 'errors', 'records', record_name, 'attributes', normalized_attribute, normalized_message],
+        ['lhs', 'errors', 'records', record_name, normalized_message]
+      ]
     end
 
     def parse_messages(json)

--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -85,16 +85,16 @@ module LHS::Errors
     end
 
     def find_translated_error_message(attribute, message)
-      record_name = record.model_name.name.underscore
+      record_name = record ? record.model_name.name.underscore : nil
       normalized_attribute = attribute.to_s.underscore
       normalized_message = message.to_s.underscore
       [
-        ['lhs', 'errors', 'records', record_name, 'attributes', normalized_attribute, normalized_message],
-        ['lhs', 'errors', 'records', record_name, normalized_message],
+        record_name ? ['lhs', 'errors', 'records', record_name, 'attributes', normalized_attribute, normalized_message] : nil,
+        record_name ? ['lhs', 'errors', 'records', record_name, normalized_message] : nil,
         ['lhs', 'errors', 'messages', normalized_message],
         ['lhs', 'errors', 'attributes', normalized_attribute, normalized_message],
         ['lhs', 'errors', 'fallback_message']
-      ].detect do |path|
+      ].compact.detect do |path|
         key = path.join('.')
         return I18n.translate(key) if I18n.exists?(key)
       end

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -228,5 +228,13 @@ describe LHS::Item do
       expect(record.reviews.last.errors).to be
       expect(record.reviews.last.errors[:name]).to include 'UNSUPPORTED_PROPERTY_VALUE'
     end
+
+    context 'accessing no model' do
+      it 'does not raise an error when trying to find error record model name' do
+        expect(lambda do
+          record.reviews.first.errors[:name]
+        end).not_to raise_error(NoMethodError)
+      end
+    end
   end
 end


### PR DESCRIPTION
*PATCH VERSION*


## BEFORE
```
undefined method `model_name' for nil:NilClass
lhs (11.2.0) lib/lhs/errors/base.rb:88:in `find_translated_error_message'
lhs (11.2.0) lib/lhs/errors/base.rb:84:in `generate_message'
lhs (11.2.0) lib/lhs/errors/base.rb:35:in `set'
lhs (11.2.0) lib/lhs/errors/base.rb:41:in `[]'
```

## NOW
Smooth as silk