### PR TITLE
Fix url parsing for records using host placeholders

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.0.0'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'lhc', '>= 5.0.3'
+  s.add_dependency 'lhc', '>= 5.1.1'
   s.add_dependency 'activesupport', '> 4.2'
 
   s.add_development_dependency 'rspec-rails', '>= 3.0.0'

--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -56,12 +56,16 @@ class LHS::Record
 
       # Computes the url from params
       # by identifiying endpoint and compiles it if necessary.
-      # Id in params is threaded in a special way.
       def compute_url!(params)
         endpoint = find_endpoint(params)
         url = endpoint.compile(params)
         endpoint.remove_interpolated_params!(params)
         url
+      end
+
+      def compute_url(params)
+        find_endpoint(params)
+          .compile(params)
       end
 
       private

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -212,7 +212,7 @@ describe LHS::Record do
       end
     end
 
-    context 'include a known/identifyable record' do
+    context 'include a known/identifiable record' do
       before(:each) do
         class Contract < LHS::Record
           endpoint 'http://datastore/contracts/:id'
@@ -253,7 +253,7 @@ describe LHS::Record do
           )
       end
 
-      it 'loads included identifyable records withou raising exceptions' do
+      it 'loads included identifiable records without raising exceptions' do
         customer = Customer.includes_all(contracts: :entry).find(1, 2).first
         expect(customer.contracts.first.href).to eq 'http://datastore/contracts/1'
         expect(customer.contracts.first.type).to eq 'contract'

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -213,7 +213,6 @@ describe LHS::Record do
     end
 
     context 'include a known/identifyable record' do
-
       before(:each) do
         class Contract < LHS::Record
           endpoint 'http://datastore/contracts/:id'
@@ -255,7 +254,7 @@ describe LHS::Record do
       end
 
       it 'loads included identifyable records withou raising exceptions' do
-        customer = Customer.includes_all(contracts: :entry).find(1,2).first
+        customer = Customer.includes_all(contracts: :entry).find(1, 2).first
         expect(customer.contracts.first.href).to eq 'http://datastore/contracts/1'
         expect(customer.contracts.first.type).to eq 'contract'
         expect(customer.contracts.first.entry.name).to eq 'Casa Ferlin'


### PR DESCRIPTION
*PATCH VERSION*

Problem:

```ruby
class Entry < LHS::Record
  endpoint ':datastore/entry/v1/:id.json'
end
``` 

Records configured with host placeholders (see above) where raising URL.parsing exceptions, as they are per se not real urls by any standards.

Solution:

Computing urls from parameters when placeholders are detected, before the urls are actually parsed.