### PR TITLE
Fix weird order for special `includes_all` case

### DIFF
--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -33,13 +33,13 @@ class LHS::Collection < LHS::Proxy
     true
   end
 
-  def compact
-    LHS::Collection.new(
-      LHS::Data.new(
-        _collection.raw.reject { |item| item.nil? }
-      )
-    )
-  end
+  # def compact
+  #   LHS::Collection.new(
+  #     LHS::Data.new(
+  #       _collection.raw.reject { |item| item.nil? }
+  #     )
+  #   )
+  # end
 
   def item?
     false

--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -33,14 +33,6 @@ class LHS::Collection < LHS::Proxy
     true
   end
 
-  # def compact
-  #   LHS::Collection.new(
-  #     LHS::Data.new(
-  #       _collection.raw.reject { |item| item.nil? }
-  #     )
-  #   )
-  # end
-
   def item?
     false
   end

--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -33,6 +33,14 @@ class LHS::Collection < LHS::Proxy
     true
   end
 
+  def compact
+    LHS::Collection.new(
+      LHS::Data.new(
+        _collection.raw.reject { |item| item.nil? }
+      )
+    )
+  end
+
   def item?
     false
   end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -94,7 +94,7 @@ class LHS::Record
           .flatten
           .each_with_index do |item, index|
             item_addition = addition[index]
-            next if item_addition.nil? or item.nil?
+            next if item_addition.nil? || item.nil?
             item.merge! item_addition._raw
           end
       end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -241,6 +241,7 @@ class LHS::Record
 
       # Load additional resources that are requested with include
       def load_include(options, data, sub_includes, references)
+        options = options.compact
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         begin
@@ -301,7 +302,7 @@ class LHS::Record
       # When including all resources on one level, don't forward :includes & :references
       # as we have to fetch all resources on this level first, before we continue_including
       def prepare_option_for_include_all_request!(option)
-        return option if option.empty? || option[:url].nil?
+        return option if option.blank? || option[:url].nil?
         uri = parse_uri(option[:url], option)
         get_params = Rack::Utils.parse_nested_query(uri.query)
           .symbolize_keys

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -87,12 +87,14 @@ class LHS::Record
       end
 
       def extend_base_collection!(data, addition, key)
-        addition = addition.compact if addition.collection? || addition.is_a?(Array)
-        data
-          .map { |item| item._raw[key] }
+        data.map do |item|
+          item_raw = item._raw[key]
+          item_raw.blank? ? [nil] : item_raw
+        end
           .flatten
           .each_with_index do |item, index|
             item_addition = addition[index]
+            next if item_addition.nil? or item.nil?
             item.merge! item_addition._raw
           end
       end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -87,16 +87,14 @@ class LHS::Record
       end
 
       def extend_base_collection!(data, addition, key)
-        data.each_with_index do |item, i|
-          item = item[i] if item.is_a? LHS::Collection
-          link = item[key.to_sym]
-          next if link.blank?
-          link.merge_raw!(addition[i]) && next if !link.collection?
-
-          link.each_with_index do |item, j|
-            item.merge_raw!(addition[i + j]) if item.present?
+        addition = addition.compact if addition.collection? || addition.is_a?(Array)
+        data
+          .map { |item| item._raw[key] }
+          .flatten
+          .each_with_index do |item, index|
+            item_addition = addition[index]
+            item.merge! item_addition._raw
           end
-        end
       end
 
       def extend_base_array!(data, addition, key)
@@ -241,7 +239,6 @@ class LHS::Record
 
       # Load additional resources that are requested with include
       def load_include(options, data, sub_includes, references)
-        options = options.compact
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         begin


### PR DESCRIPTION
*PATCH*

### PROBLEM

Imagine you work with places, and a place has `category_relations`
```
{
  id: 1,
  category_relations: [ { href: 'http://datastore/category_relations/1' } ]
}
```

When multiple places have been requested, with including all their `category_relations`, places with an empty array of `category_relations` where messing up the order of extended data, which lead to weird merged state of the places objects in the end...

```
{
  id: 1,
  category_relations: [ { href: 'http://datastore/category_relations/1' } ]
}

{
  id: 2,
  category_relations: []
}

{
  id: 3,
  category_relations: [ { href: 'http://datastore/category_relations/2' }, { href: 'http://datastore/category_relations/3' } ]
}
```

Was creating a request object array looking like:
```
[ 
  { url: 'http://datastore/category_relations/1' },
  nil,
  { url: 'http://datastore/category_relations/2' },
  { url: 'http://datastore/category_relations/3' }
]
```

Because the merge is depending on the additions index, the nil was messing up and shifting everything afterwards by 1.

### FIX

Filter all those nils in the request object array, in order to prevent shifts of merged data.