### PR TITLE
Adding error status codes to error object

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,15 @@ The parameters passed to the `validates` endpoint option are used to perform the
   endpoint ':service/v2/users', validates: { path: 'validate' }            # will perform a validation via :service/v2/users/validate
 ```
 
+### HTTP Status Codes for validation errors
+
+LHS provides the http status code received when performing validations on a record, through the errors object:
+
+```ruby
+record.save
+record.errors.status_code #400
+```
+
 ### Reset validation errors
 
 Clear the error messages. Compatible with [ActiveRecord](https://github.com/rails/rails/blob/6c8cf21584ced73ade45529d11463c74b5a0c58f/activemodel/lib/active_model/errors.rb#L85).

--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -3,13 +3,14 @@ module LHS::Errors
   class Base
     include Enumerable
 
-    attr_reader :messages, :message, :raw, :record
+    attr_reader :messages, :message, :raw, :record, :status_code
 
     def initialize(response = nil, record = nil)
       @raw = response.body if response
       @record = record
       @messages = messages_from_response(response)
       @message = message_from_response(response)
+      @status_code = response.code if response
     rescue JSON::ParserError
       @messages = messages || {}
       @message = 'parse error'

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -236,5 +236,10 @@ describe LHS::Item do
         end).not_to raise_error(NoMethodError)
       end
     end
+
+    it 'provides http status code for errors' do
+      record.save
+      expect(record.errors.status_code).to eq 400
+    end
   end
 end


### PR DESCRIPTION
*MINOR*

### HTTP Status Codes for validation errors

LHS provides the http status code received when performing validations on a record, through the errors object:

```ruby
record.save
record.errors.status_code #400
```