### PR TITLE
Fix error accessor when general fallback error is configured

### DIFF
--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -32,23 +32,24 @@ module LHS::Errors
       messages[key]
     end
 
-    def set(key, value)
-      messages[key] = generate_message(key, value)
+    def set(key, message)
+      return if message.blank?
+      messages[key] = [generate_message(key, message)]
     end
 
     delegate :delete, to: :messages
 
     def [](attribute)
-      get(attribute.to_sym) || set(attribute.to_sym, [])
+      get(attribute.to_sym) || messages[attribute] = []
     end
 
-    def []=(attribute, error)
-      self[attribute] << generate_message(attribute, error)
+    def []=(attribute, message)
+      self[attribute] << generate_message(attribute, message)
     end
 
     def each
       messages.each_key do |attribute|
-        self[attribute].each { |error| yield attribute, error }
+        self[attribute].each { |message| yield attribute, message }
       end
     end
 

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -243,7 +243,6 @@ describe LHS::Item do
     end
 
     context 'with general error fallback message configured' do
-
       before(:each) do
         I18n.reload!
         I18n.backend.store_translations(:en, YAML.safe_load(translation)) if translation.present?

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -197,7 +197,7 @@ describe LHS::Item do
 
     let(:record) do
       Record.build(
-        reviews: [{ name: 123 }],
+        reviews: [{ name: 123, suggested: false }],
         address: {
           additional_line1: '',
           street: {
@@ -240,6 +240,28 @@ describe LHS::Item do
     it 'provides http status code for errors' do
       record.save
       expect(record.errors.status_code).to eq 400
+    end
+
+    context 'with general error fallback message configured' do
+
+      before(:each) do
+        I18n.reload!
+        I18n.backend.store_translations(:en, YAML.safe_load(translation)) if translation.present?
+      end
+
+      let(:translation) do
+        %q{
+          lhs:
+            errors:
+              fallback_message: 'This value is wrong'
+        }
+      end
+
+      it 'is capable to access errors/attributes that dont have any validation errors' do
+        record.save
+        expect(record.reviews.first.errors[:suggested]).to be_kind_of Array
+        expect(record.reviews.first.errors[:suggested]).to be_empty
+      end
     end
   end
 end


### PR DESCRIPTION
*PATCH*

When general error fallback message was configured, instead of return something `blank` when accessing errors, it was returning the general error message itself, which is an unwanted behaviour (bug).

Fixed with this patch.