### PR TITLE
+ to_ary for collection

### DIFF
--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -7,7 +7,7 @@ class LHS::Collection < LHS::Proxy
   include InternalCollection
   include Create
 
-  METHOD_NAMES_EXLCUDED_FROM_WRAPPING = %w(to_a map).freeze
+  METHOD_NAMES_EXLCUDED_FROM_WRAPPING = %w(to_a to_ary map).freeze
 
   delegate :select, :length, :size, to: :_collection
   delegate :_record, :_raw, to: :_data

--- a/lib/lhs/concerns/collection/internal_collection.rb
+++ b/lib/lhs/concerns/collection/internal_collection.rb
@@ -21,6 +21,10 @@ class LHS::Collection < LHS::Proxy
         @record = record
       end
 
+      def to_ary
+        map { |item| item }
+      end
+
       def each(&_block)
         raw.each do |item|
           if item.is_a? Hash

--- a/spec/collection/accessors_spec.rb
+++ b/spec/collection/accessors_spec.rb
@@ -1,4 +1,4 @@
-to_require 'rails_helper'
+require 'rails_helper'
 
 describe LHS::Collection do
   let(:items) { [{ name: 'Steve' }] }

--- a/spec/collection/accessors_spec.rb
+++ b/spec/collection/accessors_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+to_require 'rails_helper'
 
 describe LHS::Collection do
   let(:items) { [{ name: 'Steve' }] }

--- a/spec/collection/to_ary_spec.rb
+++ b/spec/collection/to_ary_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe LHS::Collection do
+  let(:items) { [{ name: 'Steve' }] }
+  let(:extra) { 'extra' }
+  let(:collection) { Record.where }
+
+  context 'to_ary' do
+    before(:each) do
+      class Record < LHS::Record
+        endpoint 'http://datastore/records`'
+      end
+      stub_request(:get, %r{http://datastore/records})
+        .to_return(body: response_data.to_json)
+    end
+
+    let(:response_data) do
+      {
+        items: items,
+        extra: extra,
+        total: 1
+      }
+    end
+
+    let(:subject) { collection.to_ary }
+
+    it 'returns an array' do
+      expect(subject).to be
+      expect(subject).to be_kind_of Array
+      expect(subject[0]).to be_kind_of Record
+      expect(subject[0].name).to eq 'Steve'
+    end
+  end
+end


### PR DESCRIPTION
*PATCH*

Some versions of rails use `to_ary` on collections passed to collection renderers with render partial.

This leads to some problems in some of our applications passing LHS Collections to rails partial renderers.

This patch fixes that problem, by implementing [to_ary](https://apidock.com/rails/ActiveRecord/Base/to_ary)