### PR TITLE
Fix error access with indifferent access

### DIFF
--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -8,11 +8,11 @@ module LHS::Errors
     def initialize(response = nil, record = nil)
       @raw = response.body if response
       @record = record
-      @messages = messages_from_response(response)
+      @messages = messages_from_response(response).with_indifferent_access
       @message = message_from_response(response)
       @status_code = response.code if response
     rescue JSON::ParserError
-      @messages = messages || {}
+      @messages = (messages || {}).with_indifferent_access
       @message = 'parse error'
       add_error(@messages, 'body', 'parse error')
     end

--- a/spec/item/add_error_spec.rb
+++ b/spec/item/add_error_spec.rb
@@ -13,7 +13,7 @@ describe LHS::Item do
       subject.errors.add(:name, 'This date is invalid')
       expect(
         subject.errors.first
-      ).to eq [:name, 'This date is invalid']
+      ).to eq ['name', 'This date is invalid']
     end
   end
 end

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -75,6 +75,14 @@ describe LHS::Item do
       expect(record.errors[:recommended]).to eq ['REQUIRED_PROPERTY_VALUE']
     end
 
+    it 'allows accessing error messages as a hash with indifferent access' do
+      stub_request(:post, "#{datastore}/feedbacks")
+        .to_return(status: 400, body: error_format_fields.to_json)
+      result = record.save
+      expect(record.errors.messages[:ratings]).to be
+      expect(record.errors.messages['ratings']).to be
+    end
+
     it 'parses field errors correctly when creation failed' do
       stub_request(:post, "#{datastore}/feedbacks")
         .to_return(status: 400, body: error_format_field_errors.to_json)

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -78,7 +78,7 @@ describe LHS::Item do
     it 'allows accessing error messages as a hash with indifferent access' do
       stub_request(:post, "#{datastore}/feedbacks")
         .to_return(status: 400, body: error_format_fields.to_json)
-      result = record.save
+      record.save
       expect(record.errors.messages[:ratings]).to be
       expect(record.errors.messages['ratings']).to be
     end

--- a/spec/record/creation_failed_spec.rb
+++ b/spec/record/creation_failed_spec.rb
@@ -40,7 +40,7 @@ describe LHS::Record do
       expect(record.errors.include?(:ratings)).to eq true
       expect(record.errors.include?(:recommended)).to eq true
       expect(record.errors[:ratings]).to eq ['REQUIRED_PROPERTY_VALUE']
-      expect(record.errors.messages).to eq(ratings: ["REQUIRED_PROPERTY_VALUE"], recommended: ["REQUIRED_PROPERTY_VALUE"])
+      expect(record.errors.messages).to eq('ratings' => ["REQUIRED_PROPERTY_VALUE"], 'recommended' => ["REQUIRED_PROPERTY_VALUE"])
       expect(record.errors.message).to eq error_message
     end
 


### PR DESCRIPTION
*PATCH*

Access error messages hash was not able with indifferent access.

I found out that there such an access in location app: e.g. https://github.com/local-ch/location-app/blob/test-lhs-autoload/app/views/restaurants_feedbacks/_review_form.html.haml#L13

This change makes accessing error messages possible also for indifferent access.