### PR TITLE
Fix Compilation Incomplete Error when using includes_all

### DIFF
--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -63,8 +63,8 @@ class LHS::Record
         url
       end
 
-      def compute_url(params)
-        find_endpoint(params)
+      def compute_url(params, url = nil)
+        find_endpoint(params, url)
           .compile(params)
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -68,7 +68,7 @@ class LHS::Record
       def parse_uri(url, options)
         URI.parse(
           if url.match(LHC::Endpoint::PLACEHOLDER)
-            compute_url(options[:params])
+            compute_url(options[:params], url)
           else
             url
           end


### PR DESCRIPTION
_PATCH_

LHS was trying to pick an endpoint for the root Record when trying to parse an included record's href instead of a endpoint for the included record.