### PR TITLE
Fix item.dig(:something)

### DIFF
--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -8,6 +8,8 @@ class LHS::Proxy
     # FIXME: Extend the set of keywords
     BLACKLISTED_KEYWORDS = %w(new proxy_association)
 
+    delegate :dig, to: :_raw
+
     private
 
     def set(name, value)

--- a/spec/item/dig_spec.rb
+++ b/spec/item/dig_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint ':datastore/records'
+    end
+  end
+
+  let(:json) do
+    {
+      local_entry: {
+        local_entry_id: 'ABC123'
+      }
+    }
+  end
+
+  let(:item) do
+    LHS::Data.new(json, nil, Record)
+  end
+
+  it 'is possible to dig data' do
+    expect(
+      item.dig(:local_entry, :local_entry_id)
+    ).to eq 'ABC123'
+  end
+end


### PR DESCRIPTION
_PATCH_

Fixes `.dig`.
Was not working with LHS Data.

e.g. `place.dig(:local_entry, :local_entry_id)`