### PR TITLE
configure item_created_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,8 @@ end
 
 `items_key` key used to determine items of the current page (e.g. `docs`, `items`, etc.).
 
+`item_created_key` key used to merge record data thats nested in the creation response body.
+
 `limit_key` key used to work with page limits (e.g. `size`, `limit`, etc.)
 
 `pagination_key` key used to paginate multiple pages (e.g. `offset`, `page`, `startAt` etc.).
@@ -896,6 +898,27 @@ If items, limit, pagination, total etc. is nested in the responding objects, use
     configuration items_key: [:response, :businesses], limit_key: [:response, :max], pagination_key: [:response, :offset], total_key: [:response, :count], pagination_strategy: :offset
     endpoint 'http://uberall/businesses'
   end
+```
+
+If record data after creation is nested in the response body, configure the record, so that it gets properl merged with the your record instance:
+
+```
+POST /businesses
+  response: {
+    business: {
+      id: 123
+    }
+  }
+```
+
+```ruby
+  class Business < LHS::Record
+    configuration item_created_key: [:response, :business]
+    endpoint 'http://uberall/businesses'
+  end
+
+  business = Business.create(name: 'localsearch')
+  business.id # 123
 ```
 
 ### Pagination Chains

--- a/lib/lhs/concerns/record/configuration.rb
+++ b/lib/lhs/concerns/record/configuration.rb
@@ -20,6 +20,12 @@ class LHS::Record
         )
       end
 
+      def item_created_key
+        symbolize_unless_complex(
+          @configuration.try(:[], :item_created_key)
+        )
+      end
+
       def limit_key
         symbolize_unless_complex(
           @configuration.try(:[], :limit_key) || :limit
@@ -49,6 +55,7 @@ class LHS::Record
       private
 
       def symbolize_unless_complex(value)
+        return if value.blank?
         return value.to_sym unless value.is_a?(Array)
         value
       end

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -31,7 +31,11 @@ class LHS::Data
   # e.g. when loading remote data via link
   def merge_raw!(data)
     return false if data.blank? || !data._raw.is_a?(Hash)
-    _raw.merge! data._raw
+    if _record && _record.item_created_key
+      _raw.merge! data._raw.dig(*_record.item_created_key)
+    else
+      _raw.merge! data._raw
+    end
   end
 
   def _root

--- a/spec/record/items_created_key_configuration_spec.rb
+++ b/spec/record/items_created_key_configuration_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Business < LHS::Record
+      configuration item_created_key: [:response, :business], limit_key: [:response, :max], pagination_key: [:response, :offset], total_key: [:response, :count], pagination_strategy: :offset
+      endpoint 'http://uberall/businesses'
+    end
+  end
+
+  let(:stub_create_business_request) do
+    stub_request(:post, "http://uberall/businesses")
+      .to_return(body: {
+        status: "SUCCESS",
+        response: {
+          business: {
+            identifier: 'ABC123',
+            name: 'localsearch',
+            id: 239650
+          }
+        }
+      }.to_json)
+  end
+
+  it 'uses paths from configuration to access nested values' do
+    stub_create_business_request
+    business = Business.create!(
+      identifier: 'ABC123',
+      name: 'localsearch'
+    )
+    expect(business.identifier).to eq 'ABC123'
+    expect(business.name).to eq 'localsearch'
+    expect(business.id).to eq 239650
+  end
+end


### PR DESCRIPTION
_MINOR_

Is based on https://github.com/local-ch/lhs/pull/235.

If record data after creation is nested in the response body, configure the record, so that it gets properly merged with the your record instance:

```
POST /businesses
  response: {
    business: {
      id: 123
    }
  }
```

```ruby
  class Business < LHS::Record
    configuration item_created_key: [:response, :business]
    endpoint 'http://uberall/businesses'
  end

  business = Business.create(name: 'localsearch')
  business.id # 123
```
