### PR TITLE
Item#becomes

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,28 @@ record = Record.find('1z-5r1fkaj')
 record.update(recommended: false)
 ```
 
+## Becomes
+
+Based on ActiveRecord's implementation of [becomes](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes), LHS implements `becomes` too.
+It's a way to convert records of a certain type A to another certain type B.
+
+_NOTE: RPC-style actions, that are discouraged in REST anyway, can be covered with functionality too. See the following example._ 
+
+```ruby
+class Location < LHS::Record
+  endpoint 'http://sync/locations'
+  endpoint 'http://sync/locations/:id'
+end
+
+class Synchronization < LHS::Record
+  endpoint 'http://sync/locations/:id/sync'
+end
+
+location = Location.find(1)
+synchronization = location.becomes(Synchronization)
+synchronization.save!
+```
+
 ## Destroy
 
 You can delete records remotely by calling `destroy` on an LHS::Record.

--- a/README.md
+++ b/README.md
@@ -672,10 +672,10 @@ record.update(recommended: false)
 
 ## Becomes
 
-Based on ActiveRecord's implementation of [becomes](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes), LHS implements `becomes` too.
+Based on [ActiveRecord's implementation](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes), LHS implements `becomes`, too.
 It's a way to convert records of a certain type A to another certain type B.
 
-_NOTE: RPC-style actions, that are discouraged in REST anyway, can be covered with functionality too. See the following example._ 
+_NOTE: RPC-style actions, that are discouraged in REST anyway, are utilizable with this functionality, too. See the following example:_ 
 
 ```ruby
 class Location < LHS::Record

--- a/lib/lhs/concerns/item/becomes.rb
+++ b/lib/lhs/concerns/item/becomes.rb
@@ -1,0 +1,12 @@
+require 'active_support'
+
+class LHS::Item < LHS::Proxy
+
+  module Becomes
+    extend ActiveSupport::Concern
+
+    def becomes(klass)
+      klass.new(_raw)
+    end
+  end
+end

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -1,6 +1,8 @@
 # An item is a concrete record.
 # It can be part of another proxy like collection.
 class LHS::Item < LHS::Proxy
+  autoload :Becomes,
+    'lhs/concerns/item/becomes'
   autoload :Destroy,
     'lhs/concerns/item/destroy'
   autoload :Save,
@@ -10,6 +12,7 @@ class LHS::Item < LHS::Proxy
   autoload :Validation,
     'lhs/concerns/item/validation'
 
+  include Becomes
   include Create
   include Destroy
   include Save

--- a/spec/item/becomes_spec.rb
+++ b/spec/item/becomes_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  before(:each) do
+    class Location < LHS::Record
+      endpoint 'http://sync/locations'
+      endpoint 'http://sync/locations/:id'
+    end
+
+    class Synchronization < LHS::Record
+      endpoint 'http://sync/locations/:id/sync'
+    end
+
+    stub_request(:get, "http://sync/locations/1")
+      .to_return(body: {
+        id: 1,
+        name: 'localsearch'
+      }.to_json)
+
+    stub_request(:post, "http://sync/locations/1/sync")
+      .with(body: {
+        name: 'localsearch'
+      }.to_json)
+      .to_return(status: 201)
+  end
+
+  context 'convert records from class A to class B' do
+    it "becomes a record of another class" do
+      location = Location.find(1)
+      synchronization = location.becomes(Synchronization)
+      expect(synchronization).to be_kind_of(Synchronization)
+      synchronization.save!
+      expect(synchronization).to be_kind_of(Synchronization)
+    end
+  end
+end


### PR DESCRIPTION
_MINOR_

## Becomes

Based on [ActiveRecord's implementation](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes), LHS implements `becomes`, too.
It's a way to convert records of a certain type A to another certain type B.

_NOTE: RPC-style actions, that are discouraged in REST anyway, are utilizable with this functionality, too. See the following example:_ 

```ruby
class Location < LHS::Record
  endpoint 'http://sync/locations'
  endpoint 'http://sync/locations/:id'
end

class Synchronization < LHS::Record
  endpoint 'http://sync/locations/:id/sync'
end

location = Location.find(1)
synchronization = location.becomes(Synchronization)
synchronization.save!
```