### PR TITLE
clean filestore

### DIFF
--- a/lib/lhs/concerns/record/request_cycle_cache/interceptor.rb
+++ b/lib/lhs/concerns/record/request_cycle_cache/interceptor.rb
@@ -16,7 +16,8 @@ class LHS::Record
           cache_expires_in: 5.minutes,
           cache_race_condition_ttl: 5.seconds,
           cache_key: cache_key_for(request),
-          cached_methods: CACHED_METHODS
+          cached_methods: CACHED_METHODS,
+          preemptively_clean_filestore: true
         }.merge(request.options))
       end
 


### PR DESCRIPTION
https://jira.localsearch.ch/browse/WEB-4155

Set an option `preemptively_clean_filestore: true`, that'll prompt LHC to call `cache.cleanup`. This is to keep the nr of files in check, should a `ActiveSupport::Cache::FileStore` be used as a backend.

see: https://github.com/local-ch/lhc/pull/93

- [ ] check how to test this: https://github.com/local-ch/lhs/pull/238/files#diff-9dae006fe9b8a0271a3fcc147ebdbb28R19