### PR TITLE
Proxy#reload! also with id

### DIFF
--- a/lib/lhs/proxy.rb
+++ b/lib/lhs/proxy.rb
@@ -17,6 +17,7 @@ class LHS::Proxy
 
   # prevent clashing with attributes of underlying data
   attr_accessor :_data, :_loaded
+  delegate :_record, to: :_data, allow_nil: true
 
   def initialize(data)
     self._data = data
@@ -44,9 +45,13 @@ class LHS::Proxy
 
   private
 
+  def as_record
+    @as_record ||= becomes(_record)
+  end
+
   def reload_options
     return { url: _data.href } if _data.href
-    return { params: { id: _data.id } } if _data.id
+    return { params: { id: as_record.id } } if as_record.id
     {}
   end
 end

--- a/lib/lhs/proxy.rb
+++ b/lib/lhs/proxy.rb
@@ -33,12 +33,20 @@ class LHS::Proxy
   end
 
   def reload!(options = nil)
-    raise 'No href found' unless _data.href
     options = {} if options.blank?
-
-    data = _data.class.request(options.merge(url: _data.href, method: :get))
+    data = _data.class.request(
+      options.merge(method: :get).merge(reload_options)
+    )
     _data.merge_raw!(data)
     self._loaded = true
     self
+  end
+
+  private
+
+  def reload_options
+    return { url: _data.href } if _data.href
+    return { params: { id: _data.id } } if _data.id
+    {}
   end
 end

--- a/spec/record/reload_by_id_spec.rb
+++ b/spec/record/reload_by_id_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://datastore/records'
+      endpoint 'http://datastore/records/:id'
+    end
+  end
+
+  context 'reload!' do
+    it 'reloads the record by id' do
+      stub_request(:post, "http://datastore/records")
+        .to_return(body: { id: 1, name: 'Steve' }.to_json)
+      record = Record.create!(name: 'Steve')
+      stub_request(:get, "http://datastore/records/1")
+        .to_return(body: { id: 1, name: 'Steve', async: 'data' }.to_json)
+      record.reload!
+      expect(record.async).to eq 'data'
+    end
+  end
+end

--- a/spec/record/reload_by_id_spec.rb
+++ b/spec/record/reload_by_id_spec.rb
@@ -6,6 +6,15 @@ describe LHS::Record do
       endpoint 'http://datastore/records'
       endpoint 'http://datastore/records/:id'
     end
+
+    class AnotherRecord < LHS::Record
+      endpoint 'http://datastore/otherrecords'
+      endpoint 'http://datastore/otherrecords/:id'
+
+      def id
+        another_id
+      end
+    end
   end
 
   context 'reload!' do
@@ -15,6 +24,16 @@ describe LHS::Record do
       record = Record.create!(name: 'Steve')
       stub_request(:get, "http://datastore/records/1")
         .to_return(body: { id: 1, name: 'Steve', async: 'data' }.to_json)
+      record.reload!
+      expect(record.async).to eq 'data'
+    end
+
+    it 'reloads the record by id if a record method defines the actual id' do
+      stub_request(:post, "http://datastore/otherrecords")
+        .to_return(body: { another_id: 2, name: 'Can' }.to_json)
+      record = AnotherRecord.create!(name: 'Can')
+      stub_request(:get, "http://datastore/otherrecords/2")
+        .to_return(body: { id: 2, name: 'Can', async: 'data' }.to_json)
       record.reload!
       expect(record.async).to eq 'data'
     end


### PR DESCRIPTION
_PATCH_

Due to the fact that within localsearch we heavily rely on hrefs, `reload!` was not take in consideration to reload records by present id, wich can be necessary for other APIs, like uberall.