### PR TITLE
Adding Chain#fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ record = Record.where(color: 'blue')
 
 [List of possible error classes](https://github.com/local-ch/lhc/tree/master/lib/lhc/errors)
 
+## Resolve chains
+
+LHS Chains can be resolved with `fetch`, similiar to ActiveRecord:
+
+```ruby
+record = Record.where(color: 'blue').fetch
+```
+
 ## Find single records
 
 `find` finds a unique record by unique identifier (usualy id or href).

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ record = Record.where(color: 'blue')
 LHS Chains can be resolved with `fetch`, similiar to ActiveRecord:
 
 ```ruby
-record = Record.where(color: 'blue').fetch
+records = Record.where(color: 'blue').fetch
 ```
 
 ## Find single records

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -273,6 +273,10 @@ class LHS::Record
         end
       end
 
+      def fetch
+        resolve
+      end
+
       protected
 
       def method_missing(name, *args, &block)

--- a/spec/record/fetch_spec.rb
+++ b/spec/record/fetch_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://datastore/records/'
+    end
+  end
+
+  context 'fetch' do
+    let!(:request_stub) do
+      stub_request(:get, "http://datastore/records/?available=true&color=blue&range=%3E26")
+        .to_return(body: [{
+          name: 'Steve'
+        }].to_json)
+    end
+
+    it 'resolves chains' do
+      records = Record.where(color: 'blue').where(range: '>26', available: true).fetch
+      expect(request_stub).to have_been_requested
+      expect(records.first.name).to eq 'Steve'
+    end
+  end
+end


### PR DESCRIPTION
_MINOR_

Implements: https://github.com/local-ch/lhs/issues/189

[ActiveRecords' fetch](https://github.com/rails/rails/blob/92703a9ea5d8b96f30e0b706b801c9185ef14f0e/activerecord/lib/active_record/type/type_map.rb#L17)

## Resolve chains

LHS Chains can be resolved with `fetch`, similiar to ActiveRecord:

```ruby
records = Record.where(color: 'blue').fetch
```