### PR TITLE
Compatible with LHC 6.3.0

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.0.0'
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_dependency 'lhc', '>= 5.1.1'
+  s.add_dependency 'lhc', '>= 6.3.0'
   s.add_dependency 'activesupport', '> 4.2'
   s.add_dependency 'activemodel'
 

--- a/lib/lhs/concerns/data/to_hash.rb
+++ b/lib/lhs/concerns/data/to_hash.rb
@@ -6,7 +6,7 @@ class LHS::Data
     extend ActiveSupport::Concern
 
     included do
-      delegate :to_h, :to_hash, to: :_raw
+      delegate :to_h, :to_hash, to: :_raw, allow_nil: true
     end
   end
 end

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -8,7 +8,7 @@ class LHS::Proxy
     # FIXME: Extend the set of keywords
     BLACKLISTED_KEYWORDS = %w(new proxy_association)
 
-    delegate :dig, to: :_raw
+    delegate :dig, to: :_raw, allow_nil: true
 
     private
 
@@ -19,7 +19,7 @@ class LHS::Proxy
 
     def get(name, *args)
       name = args.first if name == :[]
-      value = _data._raw[name.to_s]
+      value = _data._raw[name.to_s] if _data._raw
       if value.nil? && _data._raw.present? && _data._raw.is_a?(Hash)
         value = _data._raw[name.to_sym]
         value = _data._raw[name.to_s.classify.to_sym] if value.nil?

--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -151,7 +151,8 @@ module LHS::Errors
     end
 
     def message_from_response(response = nil)
-      return unless response
+      return if response.blank? 
+      raise JSON::ParserError if response.body.blank?
       json = JSON.parse(response.body)
       json['message']
     end

--- a/lib/lhs/errors/base.rb
+++ b/lib/lhs/errors/base.rb
@@ -151,7 +151,7 @@ module LHS::Errors
     end
 
     def message_from_response(response = nil)
-      return if response.blank? 
+      return if response.blank?
       raise JSON::ParserError if response.body.blank?
       json = JSON.parse(response.body)
       json['message']

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -19,7 +19,7 @@ class LHS::Item < LHS::Proxy
   include Update
   include Validation
 
-  delegate :present?, :blank?, :empty?, to: :_raw
+  delegate :present?, :blank?, :empty?, to: :_raw, allow_nil: true
   delegate :_raw, to: :_data
 
   def collection?


### PR DESCRIPTION
_PATCH_

LHC 6.3.0 introduces response bodies being `nil`, this has to be taken in account for some of LHS' edgecases.