### PR TITLE
use a configurable cache store for the request cycle cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gem 'lhs'
 LHS comes with Request Cycle Cache – enabled by default. It requires [LHC Caching Interceptor](https://github.com/local-ch/lhc/blob/master/docs/interceptors/caching.md) to be enabled:
 
 ```ruby
-# intializers/lhc.rb 
+# intializers/lhc.rb
 LHC.configure do |config|
   config.interceptors = [LHC::Caching]
 end
@@ -285,7 +285,7 @@ You can apply options to the request chain. Those options will be forwarded to t
 
 ## Request Cycle Cache
 
-By default, LHS does not perform the same http request during one request cycle multiple times. 
+By default, LHS does not perform the same http request during one request cycle multiple times.
 
 It uses the [LHC Caching Interceptor](https://github.com/local-ch/lhc/blob/master/docs/interceptors/caching.md) as caching mechanism base and sets a unique request id for every request cycle with Railties to ensure data is just cached within one request cycle and not shared with other requests.
 
@@ -297,6 +297,12 @@ If you want to disable the LHS Request Cycle Cache, simply disable it within con
 
 ```ruby
 LHS.config.request_cycle_cache_enabled = false
+```
+
+By default the LHS Request Cycle Cache will use `ActiveSupport::Cache::MemoryStore` as its cache store. Feel free to configure a cache that is better suited for your needs by:
+
+```ruby
+LHS.config.request_cycle_cache = ActiveSupport::Cache::MemoryStore.new
 ```
 
 ## Batch processing
@@ -683,7 +689,7 @@ record.update(recommended: false)
 Based on [ActiveRecord's implementation](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes), LHS implements `becomes`, too.
 It's a way to convert records of a certain type A to another certain type B.
 
-_NOTE: RPC-style actions, that are discouraged in REST anyway, are utilizable with this functionality, too. See the following example:_ 
+_NOTE: RPC-style actions, that are discouraged in REST anyway, are utilizable with this functionality, too. See the following example:_
 
 ```ruby
 class Location < LHS::Record
@@ -792,9 +798,9 @@ end
 
 # view.html
 = form_for @customer, as: :customer do |customer_form|
-  
+
   = fields_for 'customer[:address]', @customer.address, do |address_form|
-  
+
     = fields_for 'customer[:address][:street]', @customer.address.street, do |street_form|
 
       = street_form.input :name

--- a/lib/lhs/concerns/record/request_cycle_cache/interceptor.rb
+++ b/lib/lhs/concerns/record/request_cycle_cache/interceptor.rb
@@ -12,11 +12,13 @@ class LHS::Record
 
       def before_request(request)
         request.options = request.options.merge({
-          cache: true,
-          cache_expires_in: 5.minutes,
-          cache_race_condition_ttl: 5.seconds,
-          cache_key: cache_key_for(request),
-          cached_methods: CACHED_METHODS
+          cache: {
+            expires_in: 5.minutes,
+            race_condition_ttl: 5.seconds,
+            key: cache_key_for(request),
+            methods: CACHED_METHODS,
+            use: LHS.config.request_cycle_cache
+          }
         }.merge(request.options))
       end
 

--- a/lib/lhs/config.rb
+++ b/lib/lhs/config.rb
@@ -3,9 +3,12 @@ require 'singleton'
 class LHS::Config
   include Singleton
 
-  attr_accessor :request_cycle_cache_enabled
+  attr_accessor :request_cycle_cache_enabled, :request_cycle_cache
 
   def initialize
     self.request_cycle_cache_enabled ||= true
+    if defined?(ActiveSupport::Cache::MemoryStore)
+      self.request_cycle_cache ||= ActiveSupport::Cache::MemoryStore.new
+    end
   end
 end

--- a/spec/request_cycle_cache/main_spec.rb
+++ b/spec/request_cycle_cache/main_spec.rb
@@ -87,4 +87,17 @@ describe 'Request Cycle Cache', type: :request do
       expect(request).to have_been_made.times(2)
     end
   end
+
+  context 'use: cache' do
+    let!(:old_cache) { LHS.config.request_cycle_cache}
+    before { LHS.config.request_cycle_cache = double('cache') }
+    after { LHS.config.request_cycle_cache = old_cache }
+
+    it 'uses the cache passed in',
+    cleanup_before: true, request_cycle_cache: true do
+      expect(LHS.config.request_cycle_cache).to receive(:fetch).twice.and_return(nil)
+      expect(LHS.config.request_cycle_cache).to receive(:write).twice.and_return(nil)
+      get '/request_cycle_cache/simple'
+    end
+  end
 end

--- a/spec/request_cycle_cache/main_spec.rb
+++ b/spec/request_cycle_cache/main_spec.rb
@@ -90,13 +90,13 @@ describe 'Request Cycle Cache', type: :request do
 
   context 'use: cache' do
     let!(:old_cache) { LHS.config.request_cycle_cache }
-    before { LHS.config.request_cycle_cache = double('cache') }
+    before { LHS.config.request_cycle_cache = double('cache', fetch: nil, write: nil) }
     after { LHS.config.request_cycle_cache = old_cache }
 
     it 'uses the cache passed in',
     cleanup_before: true, request_cycle_cache: true do
-      expect(LHS.config.request_cycle_cache).to receive(:fetch).twice.and_return(nil)
-      expect(LHS.config.request_cycle_cache).to receive(:write).twice.and_return(nil)
+      expect(LHS.config.request_cycle_cache).to receive(:fetch).at_least(:once)
+      expect(LHS.config.request_cycle_cache).to receive(:write).at_least(:once)
       get '/request_cycle_cache/simple'
     end
   end

--- a/spec/request_cycle_cache/main_spec.rb
+++ b/spec/request_cycle_cache/main_spec.rb
@@ -89,7 +89,7 @@ describe 'Request Cycle Cache', type: :request do
   end
 
   context 'use: cache' do
-    let!(:old_cache) { LHS.config.request_cycle_cache}
+    let!(:old_cache) { LHS.config.request_cycle_cache }
     before { LHS.config.request_cycle_cache = double('cache') }
     after { LHS.config.request_cycle_cache = old_cache }
 

--- a/spec/support/request_cycle_cache.rb
+++ b/spec/support/request_cycle_cache.rb
@@ -3,5 +3,6 @@ RSpec.configure do |config|
     enabled = spec.metadata.key?(:request_cycle_cache) && spec.metadata[:request_cycle_cache] == true
     enabled ||= false
     LHS.config.request_cycle_cache_enabled = enabled
+    LHS.config.request_cycle_cache = ActiveSupport::Cache::MemoryStore.new
   end
 end


### PR DESCRIPTION
_PATCH_

fixes: https://jira.localsearch.ch/browse/WEB-4155 by introducing a configurable cache for the request cycle cache interceptor. 

it will try to use a `ActiveSupport::Cache::MemoryStore` if defined