### PR TITLE
add test-support for RequestCycleCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1102,6 +1102,16 @@ it 'displays contracts' do
 end
 ```
 
+## Test support (caching)
+
+Add to your spec_helper.rb:
+
+```ruby
+  require 'lhs/test/request_cycle_cache.rb'
+```
+
+This will initialize a MemoryStore cache for LHC::Caching interceptor and resets the cache before every test.
+
 ## Where values hash
 
 Returns a hash of where conditions.

--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ end
 Add to your spec_helper.rb:
 
 ```ruby
-  require 'lhs/test/request_cycle_cache.rb'
+  require 'lhs/test/request_cycle_cache'
 ```
 
 This will initialize a MemoryStore cache for LHC::Caching interceptor and resets the cache before every test.

--- a/lib/lhs/test/request_cycle_cache_helper.rb
+++ b/lib/lhs/test/request_cycle_cache_helper.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.before(:each) do
+    LHS.config.request_cycle_cache.clear
+  end
+end


### PR DESCRIPTION
_PATCH_

I noticed some weird test-fails on salesbutler (https://ci.local.ch/cider-ci/ui/workspace/jobs/6b3ac0dd-5c2e-481b-8761-000b512bf07a) after switching to the new implementation of RequestCycleCache. So I guess this is necessary?