### PR TITLE
Ignore errors improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ record = Record.where(color: 'blue')
 
 If an error handler returns `nil` an empty LHS::Record is returned, not `nil`!
 
-In case you want to ignore errores and continue working with `nil` in those cases,
+In case you want to ignore errors and continue working with `nil` in those cases,
 please use `ignore`:
 
 ```ruby

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -389,7 +389,7 @@ class LHS::Record
       end
 
       def chain_pagination
-        @chain_pagination ||= resolve_pagination _links.select { |link| link.is_a? Pagination }
+        @chain_pagination ||= resolve_pagination(_links.select { |link| link.is_a? Pagination })
       end
 
       def chain_includes

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -45,8 +45,12 @@ class LHS::Record
         Chain.new(self, ErrorHandling.new(error_class => handler))
       end
 
-      def ignore(error_class)
-        Chain.new(self, IgnoredError.new(error_class))
+      def ignore(*error_classes)
+        chain = Chain.new(self, IgnoredError.new(error_classes.shift))
+        error_classes.each do |error_class|
+          chain._links.push(IgnoredError.new(error_class))
+        end
+        chain
       end
 
       def includes(*args)
@@ -201,8 +205,12 @@ class LHS::Record
         push(Option.new(hash))
       end
 
-      def ignore(error_class)
-        push(IgnoredError.new(error_class))
+      def ignore(*error_classes)
+        chain = chain.push(IgnoredError.new(error_classes.shift))
+        error_classes.each do |error_class|
+          chain = chain.push(IgnoredError.new(error_class))
+        end
+        chain
       end
 
       def page(page)

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -206,9 +206,9 @@ class LHS::Record
       end
 
       def ignore(*error_classes)
-        chain = chain.push(IgnoredError.new(error_classes.shift))
+        chain = push(IgnoredError.new(error_classes.shift))
         error_classes.each do |error_class|
-          chain = chain.push(IgnoredError.new(error_class))
+          chain._links.push(IgnoredError.new(error_class))
         end
         chain
       end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -22,7 +22,7 @@ class LHS::Record
       private
 
       def filter_empty_request_options(options)
-        options.each_with_index.map do |option|
+        options.map do |option|
           option if !option || !option.key?(:url) || !option[:url].nil?
         end
       end

--- a/spec/record/ignore_errors_spec.rb
+++ b/spec/record/ignore_errors_spec.rb
@@ -11,11 +11,8 @@ describe LHS::Record do
   end
 
   context 'ignore errors' do
-    before(:each) do
-      stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 404)
-    end
-
     it 'allows to ignore errors' do
+      stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 404)
       record = Record
         .where(color: 'blue')
         .ignore(LHC::NotFound)
@@ -51,6 +48,33 @@ describe LHS::Record do
     record = Record
       .ignore(LHC::Error)
       .where(color: 'blue')
+      .fetch
+    expect(record).to eq nil
+  end
+
+  it 'can ignore multiple error with one ignore call' do
+    stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 401)
+    record = Record
+      .ignore(LHC::Unauthorized, LHC::NotFound)
+      .where(color: 'blue')
+      .fetch
+    expect(record).to eq nil
+  end
+
+  it 'can ignore multiple error with one ignore call, on chain start' do
+    stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 401)
+    record = Record
+      .ignore(LHC::Unauthorized, LHC::NotFound)
+      .where(color: 'blue')
+      .fetch
+    expect(record).to eq nil
+  end
+
+  it 'can ignore multiple error with one ignore call, also within the chain' do
+    stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 401)
+    record = Record
+      .where(color: 'blue')
+      .ignore(LHC::Unauthorized, LHC::NotFound)
       .fetch
     expect(record).to eq nil
   end


### PR DESCRIPTION
Implements some feedback from @Averethel (crazy stuff)... https://github.com/local-ch/lhs/pull/244

Most important improvements is the ability to provide a list of ignored errors:

```ruby
Record
  .ignore(LHC::Unauthorized, LHC::Forbidden)
  .where(color: :blue)
```