### PR TITLE
Reload returns instance of correct type now

### DIFF
--- a/lib/lhs/proxy.rb
+++ b/lib/lhs/proxy.rb
@@ -40,6 +40,7 @@ class LHS::Proxy
     )
     _data.merge_raw!(data)
     self._loaded = true
+    return becomes(_record) if _record
     self
   end
 

--- a/spec/record/reload_spec.rb
+++ b/spec/record/reload_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://datastore/records'
+      endpoint 'http://datastore/records/:id'
+    end
+  end
+
+  let(:json) do
+    { id: 1, name: 'Steve' }.to_json
+  end
+
+  context 'reload!' do
+    it 'returns an instance of the record, not an LHS::Item' do
+      stub_request(:post, "http://datastore/records").to_return(body: json)
+      stub_request(:get, "http://datastore/records/1").to_return(body: json)
+      record = Record.create!(name: 'Steve')
+      expect(record).to be_kind_of Record
+      expect(record.reload!).to be_kind_of Record
+    end
+  end
+end


### PR DESCRIPTION
_PATCH_

LHS was returning objects from type LHS::Item rather then the correct Record class on `reload!`.

Fixes: https://github.com/local-ch/lhs/issues/249

### Before

```ruby
record.reload! # LHS::Item
```

### Now

```ruby
record.reload! # LHS::Record
```