### PR TITLE
Improve load all

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ Record.all(color: 'blue')
 # All three are doing the same thing: fetching all records with the color 'blue' from the endpoint while resolving pagingation if endpoint is paginated
 ```
 
+In case an API does not provide pagination information (limit, offset and total), LHS keeps on loading pages when requesting `all` until the first empty page responds.
+
 [Count vs. Length](#count-vs-length)
 
 `find_each` is a more fine grained way to process single records that are fetched in batches.

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -21,6 +21,15 @@ class LHS::Record
 
       private
 
+      def single_request_load_and_merge_remaining_objects!(data, options, endpoint)
+        return unless options[:all]
+        load_and_merge_remaining_objects!(
+          data: data,
+          options: process_options(options, endpoint),
+          load_not_paginated_collection: true
+        )
+      end
+
       def filter_empty_request_options(options)
         options.map do |option|
           option if !option || !option.key?(:url) || !option[:url].nil?
@@ -208,29 +217,28 @@ class LHS::Record
       # we can evaluate if there are further remote objects remaining
       # and after preparing all the requests that have to be made in order to fetch all
       # remote items during this batch, they are fetched in parallel
-      def load_and_merge_remaining_objects!(data, options)
+      def load_and_merge_remaining_objects!(data:, options:, load_not_paginated_collection: false)
         if paginated?(data._raw)
           load_and_merge_paginated_collection!(data, options)
         elsif data.collection? && paginated?(data.first.try(:_raw))
           load_and_merge_set_of_paginated_collections!(data, options)
-        else
+        elsif load_not_paginated_collection
           load_and_merge_not_paginated_collection!(data, options)
         end
       end
 
       def load_and_merge_not_paginated_collection!(data, options)
-        return if !options.is_a?(Hash) ||
-            options[:params].blank? ||
-            options[:params][pagination_key].blank? ||
-            options[:params][limit_key].blank?
-        options[:params].merge!(
-          limit_key => options[:params][limit_key],
+        return if data.length.zero?
+        options = options.is_a?(Hash) ? options : {}
+        limit = options.dig(:params, limit_key) || pagination_class::DEFAULT_LIMIT
+        offset = options.dig(:params, pagination_key) || pagination_class::DEFAULT_OFFSET
+        options[:params] = options.fetch(:params, {}).merge(
+          limit_key => limit,
           pagination_key => pagination_class.next_offset(
-            options[:params][pagination_key],
-            options[:params][limit_key]
+            offset,
+            limit
           )
         )
-        return if data.length.zero?
         additional_data = data._record.request(options)
         additional_data.each do |item_data|
           data.concat(input: data._raw, items: [item_data], record: self)
@@ -238,6 +246,7 @@ class LHS::Record
       end
 
       def load_and_merge_paginated_collection!(data, options)
+        data._raw[limit_key] = data.length if data._raw[limit_key].blank? && !data.length.zero?
         pagination = data._record.pagination(data)
         return data if pagination.pages_left.zero?
         record = data._record
@@ -300,13 +309,13 @@ class LHS::Record
       # paginates itself to ensure all records are fetched
       def load_all_included!(record, options)
         data = record.request(options)
-        load_and_merge_remaining_objects!(data, options)
+        load_and_merge_remaining_objects!(data: data, options: options)
         data
       end
 
       # Checks if given raw is paginated or not
       def paginated?(raw)
-        !!(raw.is_a?(Hash) && raw[total_key] && raw[pagination_key])
+        !!(raw.is_a?(Hash) && raw[total_key])
       end
 
       def prepare_options_for_include_all_request!(options)
@@ -487,7 +496,7 @@ class LHS::Record
         apply_limit!(options) if options[:all]
         response = LHC.request(process_options(options, endpoint))
         data = LHS::Data.new(response.body, nil, self, response.request, endpoint)
-        load_and_merge_remaining_objects!(data, process_options(options, endpoint)) if options[:all]
+        single_request_load_and_merge_remaining_objects!(data, options, endpoint)
         expand_items(data, options[:expanded]) if data.collection? && options[:expanded]
         handle_includes(including, data, referencing) if including.present? && data.present?
         data

--- a/lib/lhs/pagination/base.rb
+++ b/lib/lhs/pagination/base.rb
@@ -25,7 +25,7 @@ module LHS::Pagination
     end
 
     def offset
-      data._raw.dig(*_record.pagination_key) || 0
+      data._raw.dig(*_record.pagination_key) || self.class::DEFAULT_OFFSET
     end
     alias current_page offset
     alias start offset

--- a/lib/lhs/pagination/offset.rb
+++ b/lib/lhs/pagination/offset.rb
@@ -1,5 +1,7 @@
 class LHS::Pagination::Offset < LHS::Pagination::Base
 
+  DEFAULT_OFFSET = 0
+
   def current_page
     (offset + limit) / limit
   end

--- a/lib/lhs/pagination/offset.rb
+++ b/lib/lhs/pagination/offset.rb
@@ -5,10 +5,14 @@ class LHS::Pagination::Offset < LHS::Pagination::Base
   end
 
   def next_offset(step = 1)
-    offset + limit * step
+    self.class.next_offset(offset, limit, step)
   end
 
   def self.page_to_offset(page, limit = DEFAULT_LIMIT)
     (page.to_i - 1) * limit.to_i
+  end
+
+  def self.next_offset(offset, limit, step = 1)
+    offset.to_i + limit.to_i * step.to_i
   end
 end

--- a/lib/lhs/pagination/page.rb
+++ b/lib/lhs/pagination/page.rb
@@ -1,5 +1,7 @@
 class LHS::Pagination::Page < LHS::Pagination::Base
 
+  DEFAULT_OFFSET = 1
+
   def current_page
     offset
   end

--- a/lib/lhs/pagination/page.rb
+++ b/lib/lhs/pagination/page.rb
@@ -5,6 +5,10 @@ class LHS::Pagination::Page < LHS::Pagination::Base
   end
 
   def next_offset(step = 1)
-    current_page + step
+    self.class.next_offset(current_page, limit, step)
+  end
+
+  def self.next_offset(current_page, _limit, step = 1)
+    current_page.to_i + step.to_i
   end
 end

--- a/lib/lhs/pagination/start.rb
+++ b/lib/lhs/pagination/start.rb
@@ -1,5 +1,7 @@
 class LHS::Pagination::Start < LHS::Pagination::Base
 
+  DEFAULT_OFFSET = 1
+
   def current_page
     (offset + limit - 1) / limit
   end

--- a/lib/lhs/pagination/start.rb
+++ b/lib/lhs/pagination/start.rb
@@ -5,10 +5,14 @@ class LHS::Pagination::Start < LHS::Pagination::Base
   end
 
   def next_offset(step = 1)
-    offset + limit * step
+    self.class.next_offset(offset, limit, step)
   end
 
   def self.page_to_offset(page, limit = DEFAULT_LIMIT)
     (page.to_i - 1) * limit.to_i + 1
+  end
+
+  def self.next_offset(offset, limit, step = 1)
+    offset.to_i + limit.to_i * step.to_i
   end
 end

--- a/spec/record/all_spec.rb
+++ b/spec/record/all_spec.rb
@@ -92,5 +92,14 @@ describe LHS::Record do
       records = Category.limit(10).all(language: 'en').fetch
       expect(records.length).to eq 30
     end
+
+    it 'is able to fetch all remote objects without any current page indicator by simply increasing the offset until response is empty' do
+      stub_batch('http://store/categories?language=en&max=100', 100)
+      stub_batch('http://store/categories?language=en&max=100&offset=100', 100)
+      stub_batch('http://store/categories?language=en&max=100&offset=200', 100)
+      stub_batch('http://store/categories?language=en&max=100&offset=300', 0)
+      records = Category.all(language: 'en').fetch
+      expect(records.length).to eq 300
+    end
   end
 end

--- a/spec/record/endpoints_spec.rb
+++ b/spec/record/endpoints_spec.rb
@@ -81,6 +81,8 @@ describe LHS::Record do
       it 'uses urls instead of trying to find base endpoint of parent class' do
         stub_request(:get, "#{datastore}/entry/123/contracts?limit=100")
           .to_return(body: [{ product: { href: "#{datastore}/products/LBC" } }].to_json)
+        stub_request(:get, "#{datastore}/entry/123/contracts?limit=100&offset=100")
+          .to_return(body: [].to_json)
         stub_request(:get, "#{datastore}/products/LBC")
           .to_return(body: { name: 'Local Business Card' }.to_json)
         expect(lambda {

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -346,7 +346,10 @@ describe LHS::Record do
         .to_return(
           body: {
             href:  "http://datastore/v2/places/1/contracts?offset=0&limit=10",
-            items: [{ href: "http://datastore/v2/contracts/1" }]
+            items: [{ href: "http://datastore/v2/contracts/1" }],
+            offset: 0,
+            limit: 10,
+            total: 10
           }.to_json
         )
 

--- a/spec/record/paginatable_collection_spec.rb
+++ b/spec/record/paginatable_collection_spec.rb
@@ -30,7 +30,8 @@ describe LHS::Record do
     end
 
     it 'also works when there is no total in the stubbing' do
-      stub_request(:get, %r{/feedbacks}).to_return(body: { items: (1..100).to_a }.to_json)
+      stub_request(:get, "http://local.ch/v2/feedbacks?limit=100").to_return(body: { items: (1..100).to_a }.to_json)
+      stub_request(:get, "http://local.ch/v2/feedbacks?limit=100&offset=100").to_return(body: { items: [] }.to_json)
       all = Record.all
       expect(all).to be_kind_of Record
       expect(all._proxy).to be_kind_of LHS::Collection
@@ -38,7 +39,8 @@ describe LHS::Record do
     end
 
     it 'also works when there is no key "items" in the stubbing' do
-      stub_request(:get, %r{/feedbacks}).to_return(body: (1..100).to_a.to_json)
+      stub_request(:get, "http://local.ch/v2/feedbacks?limit=100").to_return(body: (1..100).to_a.to_json)
+      stub_request(:get, "http://local.ch/v2/feedbacks?limit=100&offset=100").to_return(body: [].to_json)
       all = Record.all
       expect(all).to be_kind_of Record
       expect(all._proxy).to be_kind_of LHS::Collection


### PR DESCRIPTION
_MAJOR_
_Might break existing tests for paginated endpoints because offset is now, occasionally set_

## Batch processing

**Be careful using methods for batch processing. They could result in a lot of HTTP requests!**

`all` fetches all records from the service by doing multiple requests and resolving endpoint pagination if necessary.

[...]

**In case an API does not provide pagination information (limit, offset and total), LHS keeps on loading pages when requesting `all` until the first empty page responds.**