### PR TITLE
! count on empty collections

### DIFF
--- a/lib/lhs/pagination/base.rb
+++ b/lib/lhs/pagination/base.rb
@@ -11,14 +11,12 @@ module LHS::Pagination
       self.data = data
     end
 
-    # as standard in Rails' ActiveRecord count is not summing up, but using the number provided from data source
-    def count
-      total
+    def total
+      data._raw.dig(*_record.total_key) || 0
     end
 
-    def total
-      data._raw.dig(*_record.total_key)
-    end
+    # as standard in Rails' ActiveRecord count is not summing up, but using the number provided from data source
+    alias count total
 
     def limit
       data._raw.dig(*_record.limit_key) || DEFAULT_LIMIT

--- a/spec/data/collection_spec.rb
+++ b/spec/data/collection_spec.rb
@@ -15,6 +15,22 @@ describe LHS::Data do
     end
   end
 
+  context 'empty collection' do
+
+    let(:collection) do
+      LHS::Data.new({ items: [] }, nil, Record)
+    end
+
+    it 'provides correct count and length' do
+      expect(collection.count).to eq 0
+      expect(collection.length).to eq 0
+    end
+
+    it 'returns an empty array or map' do
+      expect(collection.map{ |x| }).to eq []
+    end
+  end
+
   context 'collections' do
     it 'forwards calls to the collection' do
       expect(data.count).to be_kind_of Integer

--- a/spec/data/collection_spec.rb
+++ b/spec/data/collection_spec.rb
@@ -16,7 +16,6 @@ describe LHS::Data do
   end
 
   context 'empty collection' do
-
     let(:collection) do
       LHS::Data.new({ items: [] }, nil, Record)
     end
@@ -27,7 +26,7 @@ describe LHS::Data do
     end
 
     it 'returns an empty array or map' do
-      expect(collection.map{ |x| }).to eq []
+      expect(collection.map { |x| }).to eq []
     end
   end
 


### PR DESCRIPTION
_PATCH_

Provides count information 0 when there is no count information in the pagination.