### PR TITLE
Unwrap single items within nested response body

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,6 +914,8 @@ class Search < LHS::Record
 end
 ```
 
+`item_key` key used to unwrap the actuall object from within the response body.
+
 `items_key` key used to determine items of the current page (e.g. `docs`, `items`, etc.).
 
 `item_created_key` key used to merge record data thats nested in the creation response body.
@@ -925,6 +927,27 @@ end
 `pagination_strategy` used to configure the strategy used for navigating (e.g. `offset`, `page`, `start`, etc.).
 
 `total_key` key used to determine the total amount of items (e.g. `total`, `totalResults`, etc.).
+
+### Unwrap nested items
+
+```json
+{
+  "response": {
+    "location": {
+      "id": 123
+    }
+  }
+}
+```
+
+```ruby
+class Location < LHS::Record
+  configuration item_key: [:response, :location]
+end
+
+location = Location.find(1)
+location.id # 123
+```
 
 ### Configure complex accessors for nested data (EXPERIMENTAL)
 

--- a/README.md
+++ b/README.md
@@ -945,7 +945,7 @@ class Location < LHS::Record
   configuration item_key: [:response, :location]
 end
 
-location = Location.find(1)
+location = Location.find(123)
 location.id # 123
 ```
 

--- a/lib/lhs/concerns/record/configuration.rb
+++ b/lib/lhs/concerns/record/configuration.rb
@@ -14,6 +14,12 @@ class LHS::Record
         @configuration = args.freeze || {}
       end
 
+      def item_key
+        symbolize_unless_complex(
+          @configuration.try(:[], :item_key) || :item
+        )
+      end
+
       def items_key
         symbolize_unless_complex(
           @configuration.try(:[], :items_key) || :items

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -18,7 +18,7 @@ class LHS::Record
             find_by_id(args, options)
           end
         return data if data && (data.is_a?(Array) || !data._record)
-        data ? data._record.new(data) : nil
+        data ? data._record.new(data.unwrap_nested_item) : nil
       end
 
       private

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -17,7 +17,7 @@ class LHS::Record
           else
             find_by_id(args, options)
           end
-        return data if data && (data.is_a?(Array) || !data._record)
+        return data if data && (data.is_a?(Array) || !data._record || data.collection?)
         data ? data._record.new(data.unwrap_nested_item) : nil
       end
 

--- a/lib/lhs/concerns/record/find_by.rb
+++ b/lib/lhs/concerns/record/find_by.rb
@@ -27,7 +27,7 @@ class LHS::Record
         if data && data._proxy.is_a?(LHS::Collection)
           data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))
         elsif data
-          data._record.new(data)
+          data._record.new(data.unwrap_nested_item)
         end
       end
     end

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -41,4 +41,11 @@ class LHS::Item < LHS::Proxy
     # We accept every message that does not belong to set of keywords
     BLACKLISTED_KEYWORDS.exclude?(name.to_s)
   end
+
+  def unwrap_nested_item
+    return _data unless _record.item_key
+    nested_data = _data.dig(*_record.item_key)
+    return _data unless nested_data
+    nested_data
+  end
 end

--- a/spec/record/item_key_spec.rb
+++ b/spec/record/item_key_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Location < LHS::Record
+      configuration item_key: [:response, :location]
+      endpoint 'http://uberall/location'
+      endpoint 'http://uberall/location/:id'
+    end
+  end
+
+  let(:json_body) do
+    {
+      response: {
+        location: {
+          id: 1
+        }
+      }
+    }.to_json
+  end
+
+  let(:stub_request_by_id) do
+    stub_request(:get, "http://uberall/location/1")
+      .to_return(body: json_body)
+  end
+
+  let(:stub_request_by_get_parameters) do
+    stub_request(:get, "http://uberall/location?identifier=1&limit=1")
+      .to_return(body: json_body)
+  end
+
+  it 'uses configured item_key to unwrap response data for find' do
+    stub_request_by_id
+    location = Location.find(1)
+    expect(location.id).to eq 1
+  end
+
+  it 'uses configured item_key to unwrap response data for find_by' do
+    stub_request_by_get_parameters
+    location = Location.find_by(identifier: 1)
+    expect(location.id).to eq 1
+  end
+end


### PR DESCRIPTION
_MINOR_

## Configuration of Records

`item_key` key used to unwrap the actuall object from within the response body.
[...]

### Unwrap nested items

```json
{
  "response": {
    "location": {
      "id": 123
    }
  }
}
```

```ruby
class Location < LHS::Record
  configuration item_key: [:response, :location]
end

location = Location.find(1)
location.id # 123
```

