### PR TITLE
Partial update

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ record.update(recommended: false)
 
 ## Partial Update
 
-Often you just want to update a single attribute on an existing record. As ActiveRecord's `update_attribute` skips validation, which is unlikely with api services, LHS uses `partial_update` for that matter.
+Often you just want to update a single attribute on an existing record. As ActiveRecord's `update_attribute` skips validation, which is unlikely with api services, and `update_attributes` is just an alias for `update`, LHS introduces `partial_update` for that matter.
 
 `partial_update` will return false if persisting fails. `partial_update!` instead will an raise exception.
 

--- a/README.md
+++ b/README.md
@@ -696,6 +696,23 @@ record = Record.find('1z-5r1fkaj')
 record.update(recommended: false)
 ```
 
+## Partial Update
+
+Often you just want to update a single attribute on an existing record. As ActiveRecord's `update_attribute` skips validation, which is unlikely with api services, LHS uses `partial_update` for that matter.
+
+`partial_update` will return false if persisting fails. `partial_update!` instead will an raise exception.
+
+`partial_update` always updates the data of the local object first, before it tries to sync with an endpoint. So even if persisting fails, the local object is updated.
+
+```ruby
+record = Record.find('1z-5r1fkaj')
+record.partial_update(recommended: false)
+# POST /records/1z-5r1fkaj
+{
+  recommended: true
+}
+```
+
 ## Becomes
 
 Based on [ActiveRecord's implementation](http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-becomes), LHS implements `becomes`, too.

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -34,11 +34,12 @@ class LHS::Item < LHS::Proxy
 
     def create_and_merge_data!(options)
       direct_response_data = record.request(options)
-      _data.merge_raw!(direct_response_data)
+      nested_path = record.item_created_key ? record.item_created_key : nil
+      _data.merge_raw!(direct_response_data, nested_path)
       response_headers = direct_response_data._request.response.headers
       if response_headers && response_headers['Location']
         location_data = record.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
-        _data.merge_raw!(location_data)
+        _data.merge_raw!(location_data, nested_path)
       end
       true
     end

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -26,17 +26,20 @@ class LHS::Item < LHS::Proxy
     def update!(params, options = {}, partial_update = false)
       options ||= {}
       partial_data = LHS::Data.new(params, _data.parent, record)
-      _data.merge_raw!(partial_data)
+      nested_path = record.item_created_key ? record.item_created_key : nil
+      _data.merge_raw!(partial_data, nested_path)
       data_sent = partial_update ? partial_data : _data
+      url = href || record.find_endpoint(id: id).compile(id: id)
       response_data = record.request(
         options.merge(
-          method: :post,
-          url: href,
+          method: options.fetch(:method, :post),
+          url: url,
           body: data_sent.to_json,
           headers: { 'Content-Type' => 'application/json' }
         )
       )
-      _data.merge_raw!(response_data)
+      nested_path = record.item_created_key ? record.item_created_key : nil
+      _data.merge_raw!(response_data, nested_path)
       true
     end
   end

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -28,13 +28,11 @@ class LHS::Data
 
   # merging data
   # e.g. when loading remote data via link
-  def merge_raw!(data)
+  def merge_raw!(data, nested_path = nil)
     return false if data.blank? || !data._raw.is_a?(Hash)
-    if _record && _record.item_created_key
-      _raw.merge! data._raw.dig(*_record.item_created_key)
-    else
-      _raw.merge! data._raw
-    end
+    raw = data._raw.dig(*nested_path) if nested_path
+    raw ||= data._raw
+    _raw.merge! raw
   end
 
   def _root

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -241,7 +241,7 @@ describe LHS::Item do
       it 'does not raise an error when trying to find error record model name' do
         expect(lambda do
           record.reviews.first.errors[:name]
-        end).not_to raise_error(NoMethodError)
+        end).not_to raise_error
       end
     end
 

--- a/spec/item/partial_update_spec.rb
+++ b/spec/item/partial_update_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint ':datastore/v2/:campaign_id/feedbacks'
+      endpoint ':datastore/v2/feedbacks'
+    end
+  end
+
+  let(:json) do
+    load_json(:feedbacks)
+  end
+
+  let(:data) do
+    LHS::Data.new(json, nil, Record)
+  end
+
+  let(:item) do
+    data[0]
+  end
+
+  context 'update' do
+    it 'persists changes on the backend' do
+      stub_request(:post, item.href)
+        .with(body: { name: 'Steve' }.to_json)
+      result = item.partial_update(name: 'Steve')
+      expect(result).to eq true
+    end
+
+    it 'returns false if persisting went wrong' do
+      stub_request(:post, item.href).to_return(status: 500)
+      result = item.partial_update(name: 'Steve')
+      expect(result).to eq false
+    end
+
+    it 'merges reponse data with object' do
+      stub_request(:post, item.href)
+        .to_return(status: 200, body: item._raw.merge(likes: 'Banana').to_json)
+      item.partial_update(name: 'Steve')
+      expect(item.name).to eq 'Steve'
+      expect(item.likes).to eq 'Banana'
+    end
+
+    it 'updates local version of an object even if BE request fails' do
+      stub_request(:post, item.href)
+        .to_return(status: 400, body: item._raw.merge(likes: 'Banana').to_json)
+      item.update(name: 'Andrea')
+      expect(item.name).to eq 'Andrea'
+      expect(item.likes).not_to eq 'Banana'
+    end
+  end
+
+  context 'update!' do
+    it 'raises if something goes wrong' do
+      stub_request(:post, item.href)
+        .with(body: { name: 'Steve' }.to_json)
+        .to_return(status: 500)
+      expect(-> { item.partial_update!(name: 'Steve') }).to raise_error LHC::ServerError
+    end
+  end
+end

--- a/spec/item/partial_update_spec.rb
+++ b/spec/item/partial_update_spec.rb
@@ -96,6 +96,15 @@ describe LHS::Item do
         expect(location.autoSync).to eq true
         expect(location.listings.first.directory).to eq 'facebook'
       end
+
+      it 'use given update http method' do
+        stub_request(:get, "http://uberall/locations/1").to_return(body: { response: { location: { id: 1 } } }.to_json)
+        stub_request(:patch, "http://uberall/locations/1").to_return(body: { response: { location: { id: 1, listings: [{ directory: 'facebook' }] } } }.to_json)
+        location = Location.find(1)
+        location.partial_update({ autoSync: true }, { method: :patch })
+        expect(location.autoSync).to eq true
+        expect(location.listings.first.directory).to eq 'facebook'
+      end
     end
   end
 end


### PR DESCRIPTION
_MINOR_

## Partial Update

Often you just want to update a single attribute on an existing record. As ActiveRecord's `update_attribute` skips validation, which is unlikely with api services, and `update_attributes` is just an alias for `update`, LHS introduces `partial_update` for that matter.

`partial_update` will return false if persisting fails. `partial_update!` instead will an raise exception.

`partial_update` always updates the data of the local object first, before it tries to sync with an endpoint. So even if persisting fails, the local object is updated.

```ruby
record = Record.find('1z-5r1fkaj')
record.partial_update(recommended: false)
# POST /records/1z-5r1fkaj
{
  recommended: true
}
```