### PR TITLE
+ make errors available if there are some

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ or with parameters:
 
 In order to validate LHS::Records before persisting them, you can use the `valid?` (`validate` alias) method.
 
-The specific endpoint has to support validations without peristance. An endpoint has to be enabled (opt-in) for validations in the service configuration.
+The specific endpoint has to support validations without persistance. An endpoint has to be enabled (opt-in) for validations in the service configuration.
 
 ```ruby
 class User < LHS::Record
@@ -843,6 +843,33 @@ lhs.errors.fallback_message
 
 ### Know issue with `ActiveModel::Validations`
 If you are using `ActiveModel::Validations` and add errors to the LHS::Record instance - as described above - then those errors will be overwritten by the errors from `ActiveModel::Validations` when using `save`  or `valid?`. [Open issue](https://github.com/local-ch/lhs/issues/159)
+
+### Blocking errors, original "errors"
+
+The fact that records could have errors is not coupled to any response status code.
+
+LHS makes errors accessible, if they are present:
+
+```
+  {
+    company_name: 'localsearch',
+    field_errors: [{
+      code: 'REQUIRED_PROPERTY_VALUE',
+      path: ['place', 'opening_hours']
+    }
+  }
+```
+
+LHS makes those errors available when accessing `.errors`:
+
+```ruby
+  presence = Presence.create(
+    place: { href: 'http://storage/places/1' }
+  )
+
+  presence.errors.any? # true
+  presence.place.errors.messages[:opening_hours] # ['REQUIRED_PROPERTY_VALUE']
+```
 
 ### Non blocking validation errors, so called warnings
 

--- a/lib/lhs/concerns/proxy/problems.rb
+++ b/lib/lhs/concerns/proxy/problems.rb
@@ -14,7 +14,8 @@ class LHS::Proxy
     end
 
     def errors
-      @errors ||= LHS::Problems::Errors.new(nil, record)
+      response = _raw.present? && _raw.is_a?(Hash) && _raw[:field_errors] ? OpenStruct.new(body: _raw.to_json) : nil
+      @errors ||= LHS::Problems::Errors.new(response, record)
     end
 
     def warnings

--- a/spec/item/access_errors_spec.rb
+++ b/spec/item/access_errors_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe LHS::Item do
+
+  context 'make errors available' do
+
+    before(:each) do
+      class Presence < LHS::Record
+        endpoint 'http://opm/presences'
+      end
+    end
+
+    let(:place_href) { 'http://datastore/places/1' }
+
+    it 'makes errors available no matter the response code' do
+      stub_request(:post, "http://opm/presences")
+        .to_return(
+          status: 200,
+          body: {
+            place: { href: place_href },
+            field_errors: [{
+              code: 'REQUIRED_PROPERTY_VALUE',
+              path: ['place', 'opening_hours']
+            }]
+          }.to_json
+        )
+      presence = Presence.create(place: { href: place_href })
+      expect(presence.errors.any?).to be true
+    end
+  end
+end


### PR DESCRIPTION
_PATCH_

Errors have not been accessible under certain circumstances. In general, when `field_errors` are part of `raw`, they should be accessible.

### Blocking errors, original "errors"

The fact that records could have errors is not coupled to any response status code.

LHS makes errors accessible, if they are present:

```
  {
    company_name: 'localsearch',
    field_errors: [{
      code: 'REQUIRED_PROPERTY_VALUE',
      path: ['place', 'opening_hours']
    }
  }
```

LHS makes those errors available when accessing `.errors`:

```ruby
  presence = Presence.create(
    place: { href: 'http://storage/places/1' }
  )

  presence.errors.any? # true
  presence.place.errors.messages[:opening_hours] # ['REQUIRED_PROPERTY_VALUE']
```