### PR TITLE
Fix reload merge

### DIFF
--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -34,12 +34,11 @@ class LHS::Item < LHS::Proxy
 
     def create_and_merge_data!(options)
       direct_response_data = record.request(options)
-      nested_path = record.item_created_key ? record.item_created_key : nil
-      _data.merge_raw!(direct_response_data, nested_path)
+      _data.merge_raw!(direct_response_data.unwrap(:item_created_key))
       response_headers = direct_response_data._request.response.headers
       if response_headers && response_headers['Location']
         location_data = record.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
-        _data.merge_raw!(location_data, nested_path)
+        _data.merge_raw!(location_data.unwrap(:item_created_key))
       end
       true
     end

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -26,8 +26,7 @@ class LHS::Item < LHS::Proxy
     def update!(params, options = {}, partial_update = false)
       options ||= {}
       partial_data = LHS::Data.new(params, _data.parent, record)
-      nested_path = record.item_created_key ? record.item_created_key : nil
-      _data.merge_raw!(partial_data, nested_path)
+      _data.merge_raw!(partial_data)
       data_sent = partial_update ? partial_data : _data
       url = href || record.find_endpoint(id: id).compile(id: id)
       response_data = record.request(
@@ -38,8 +37,7 @@ class LHS::Item < LHS::Proxy
           headers: { 'Content-Type' => 'application/json' }
         )
       )
-      nested_path = record.item_created_key ? record.item_created_key : nil
-      _data.merge_raw!(response_data, nested_path)
+      _data.merge_raw!(response_data.unwrap(:item_created_key))
       true
     end
   end

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -38,7 +38,7 @@ class LHS::Data
   # like item_key for GET etc.
   def unwrap(usecase)
     nested_path = record.send(usecase) if record
-    return LHS::Data.new(self.dig(*nested_path) || self._raw, nil, self.class) if nested_path
+    return LHS::Data.new(dig(*nested_path) || _raw, nil, self.class) if nested_path
     self
   end
 

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -28,11 +28,18 @@ class LHS::Data
 
   # merging data
   # e.g. when loading remote data via link
-  def merge_raw!(data, nested_path = nil)
+  def merge_raw!(data)
     return false if data.blank? || !data._raw.is_a?(Hash)
-    raw = data._raw.dig(*nested_path) if nested_path
-    raw ||= data._raw
-    _raw.merge! raw
+    _raw.merge! data._raw
+  end
+
+  # Unwraps data for certain use cases
+  # like items_created_key for CREATE, UPDATED etc.
+  # like item_key for GET etc.
+  def unwrap(usecase)
+    nested_path = record.send(usecase) if record
+    return LHS::Data.new(self.dig(*nested_path) || self._raw, nil, self.class) if nested_path
+    self
   end
 
   def _root

--- a/lib/lhs/proxy.rb
+++ b/lib/lhs/proxy.rb
@@ -38,7 +38,7 @@ class LHS::Proxy
     data = _data.class.request(
       options.merge(method: :get).merge(reload_options)
     )
-    _data.merge_raw!(data)
+    _data.merge_raw!(data.unwrap(:item_key))
     self._loaded = true
     return becomes(_record) if _record
     self


### PR DESCRIPTION
_PATCH_

Fixes bug where a response with nested response data was nor merged during `reload!` (Uberall case).

- Also refactors unwrap