### PR TITLE
Deep merge options when processing request options

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -434,7 +434,7 @@ class LHS::Record
         options[:ignored_errors] = ignored_errors if ignored_errors.present?
         options[:params].deep_symbolize_keys! if options[:params]
         options[:error_handler] = merge_error_handlers(options[:error_handler]) if options[:error_handler]
-        options = (endpoint.options || {}).merge(options)
+        options = (endpoint.options || {}).deep_merge(options)
         options[:url] = compute_url!(options[:params]) unless options.key?(:url)
         merge_explicit_params!(options[:params])
         options.delete(:params) if options[:params] && options[:params].empty?

--- a/spec/record/endpoint_options_spec.rb
+++ b/spec/record/endpoint_options_spec.rb
@@ -17,5 +17,27 @@ describe LHS::Record do
       stub_request(:get, "http://backend/v2/feedbacks/1").to_return(status: 200)
       Record.find(1)
     end
+
+    context 'deep merge endpoint options' do
+
+      before(:each) do
+        class Location < LHS::Record
+          endpoint 'http://uberall/locations', headers: { privateKey: '123' }
+        end
+      end
+
+      it 'deep merges options to not overwrite endpoint options' do
+        stub_request(:get, "http://uberall/locations")
+          .with(
+            headers: {
+              'Privatekey' => '123',
+              'Accept' => 'application/json'
+            }
+          )
+          .to_return(body: [].to_json)
+
+        Location.options(headers: { 'Accept' => 'application/json' }).fetch
+      end
+    end
   end
 end


### PR DESCRIPTION
_PATCH_

When endpoints had configured headers and other head options has been passed either trough certain actions, like update (accept: 'application/json') or via chain options, they have been overwritten by a shallow merge of options.

Fix is to deep merge options when processing request options.