### PR TITLE
BUGFIX: Nested field error forwarding

### DIFF
--- a/lib/lhs/problems/errors.rb
+++ b/lib/lhs/problems/errors.rb
@@ -21,7 +21,7 @@ module LHS::Problems
       messages = {}
       fields_to_errors(json, messages) if json['fields']
       field_errors_to_errors(json, messages) if json['field_errors']
-      fallback_errors(json, messages) if messages.empty?
+      fallback_errors(json, messages) if messages.empty? && !json['fields'] && !json['field_errors']
       messages
     end
 

--- a/spec/item/nested_errors_spec.rb
+++ b/spec/item/nested_errors_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+describe LHS::Item do
+
+  context 'nested data' do
+
+    before(:each) do
+      class Presence < LHS::Record
+        endpoint 'http://opm/presences'
+      end
+      stub_request(:post, "http://opm/presences")
+        .to_return(
+          body: {
+            listings: [{status: 'CONNECTED'}],
+            field_errors: []
+          }.to_json
+        )
+    end
+
+    it 'does not raise when accessing nested data' do
+      presence = Presence.create
+      expect(->{
+        presence.listings.first
+      }).not_to raise_error NoMethodError
+    end
+  end
+end

--- a/spec/item/nested_errors_spec.rb
+++ b/spec/item/nested_errors_spec.rb
@@ -3,15 +3,14 @@ require 'rails_helper'
 describe LHS::Item do
 
   context 'nested data' do
-
-    before(:each) do
+    before do
       class Presence < LHS::Record
         endpoint 'http://opm/presences'
       end
       stub_request(:post, "http://opm/presences")
         .to_return(
           body: {
-            listings: [{status: 'CONNECTED'}],
+            listings: [{ status: 'CONNECTED' }],
             field_errors: []
           }.to_json
         )
@@ -19,7 +18,7 @@ describe LHS::Item do
 
     it 'does not raise when accessing nested data' do
       presence = Presence.create
-      expect(->{
+      expect(lambda {
         presence.listings.first
       }).not_to raise_error NoMethodError
     end


### PR DESCRIPTION
_PATCH_

LHS was not capable to handle resources that contained resource and error data.

# BEFORE
```
{
  field_errors:[{code: 'REQUIRED_DATA', path: ['place]}]
}
```

# SINCE OPM
```
{
    place: { 'href': 'http://places/1' },
    field_errors:[{code: 'REQUIRED_DATA', path: ['place]}]
}
```

Because nested data handling was passing response data while accessing nested data structures, it tried to access errors within the response body, with fails for certain data structures.

This makes LHS more smart about what inside the response actually are errors and whats not.