### PR TITLE
Introducing errors.codes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,3 +32,6 @@ Metrics/BlockLength:
 
 Style/EmptyLinesAroundBlockBody:
   Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -775,7 +775,8 @@ end
 user.errors #<LHS::Problems::Errors>
 user.errors.include?(:email) # true
 user.errors[:email] # ['REQUIRED_PROPERTY_VALUE']
-user.errors.messages # {:email=>["REQUIRED_PROPERTY_VALUE"]}
+user.errors.messages # {:email=>["Translated error message that this value is required"]}
+user.errors.codes # {:email=>["REQUIRED_PROPERTY_VALUE"]}
 user.errors.message # email must be set when user is created."
 ```
 
@@ -885,7 +886,8 @@ LHS makes those errors available when accessing `.errors`:
   )
 
   presence.errors.any? # true
-  presence.place.errors.messages[:opening_hours] # ['REQUIRED_PROPERTY_VALUE']
+  presence.place.errors.messages[:opening_hours] # ['This field needs to be present']
+  presence.place.errors.codes[:opening_hours] # ['REQUIRED_PROPERTY_VALUE']
 ```
 
 ### Non blocking validation errors, so called warnings

--- a/lib/lhs/problems/base.rb
+++ b/lib/lhs/problems/base.rb
@@ -6,7 +6,7 @@ module LHS::Problems
   class Base
     include Enumerable
 
-    attr_reader :raw, :messages, :record
+    attr_reader :raw, :messages, :codes, :record
 
     def include?(attribute)
       messages[attribute].present?
@@ -55,6 +55,7 @@ module LHS::Problems
     def clear
       @raw = nil
       @messages.clear
+      @codes.clear
     end
 
     delegate :values, to: :messages
@@ -73,6 +74,8 @@ module LHS::Problems
 
     def add_error(messages, key, value)
       key = key.to_sym
+      codes[key] ||= []
+      codes[key].push(value)
       messages[key] ||= []
       messages[key].push(generate_message(key, value))
     end

--- a/lib/lhs/problems/errors.rb
+++ b/lib/lhs/problems/errors.rb
@@ -6,11 +6,13 @@ module LHS::Problems
     def initialize(response = nil, record = nil)
       @raw = response.body if response
       @record = record
+      @codes = {}.with_indifferent_access
       @messages = messages_from_response(response).with_indifferent_access
       @message = message_from_response(response)
       @status_code = response.code if response
     rescue JSON::ParserError
       @messages = (messages || {}).with_indifferent_access
+      @codes = (codes || {}).with_indifferent_access
       @message = 'parse error'
       add_error(@messages, 'body', 'parse error')
     end

--- a/lib/lhs/problems/warnings.rb
+++ b/lib/lhs/problems/warnings.rb
@@ -4,6 +4,7 @@ module LHS::Problems
     def initialize(raw, record = nil)
       @raw = raw
       @record = record
+      @codes = {}.with_indifferent_access
       @messages = warnings_from_raw
     end
 

--- a/spec/item/error_codes_spec.rb
+++ b/spec/item/error_codes_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  context 'error codes' do
+    before(:each) do
+      I18n.reload!
+      I18n.backend.store_translations(:en, YAML.safe_load(translation)) if translation.present?
+      class Record < LHS::Record
+        endpoint 'http://datastore/records'
+      end
+    end
+
+    let(:translation) do
+      %q{
+        lhs:
+          errors:
+            fallback_message: 'This value is wrong'
+      }
+    end
+
+    it 'provides error codes along side with translated messages' do
+      stub_request(:post, 'http://datastore/records')
+        .to_return(body: {
+          field_errors: [{
+            code: 'UNSUPPORTED_PROPERTY_VALUE',
+            path: ['gender'],
+            message: 'The property value is unsupported.'
+          }, {
+            code: 'INCOMPLETE_PROPERTY_VALUE',
+            path: ['gender'],
+            message: 'The property value is incomplete. It misses some data'
+          }, {
+            code: 'INCOMPLETE_PROPERTY_VALUE',
+            path: ['contract', 'entry_id'],
+            message: 'The property value is incomplete. It misses some data'
+          }]
+        }.to_json)
+      record = Record.create
+      expect(record.errors.messages['gender']).to eq(
+        ['This value is wrong', 'This value is wrong']
+      )
+      expect(record.errors.codes['gender']).to eq(
+        ['UNSUPPORTED_PROPERTY_VALUE', 'INCOMPLETE_PROPERTY_VALUE']
+      )
+      expect(record.errors.messages['contract.entry_id']).to eq(
+        ['This value is wrong']
+      )
+      expect(record.errors.codes['contract.entry_id']).to eq(
+        ['INCOMPLETE_PROPERTY_VALUE']
+      )
+    end
+  end
+end

--- a/spec/item/errors_spec.rb
+++ b/spec/item/errors_spec.rb
@@ -51,6 +51,8 @@ describe LHS::Item do
   end
 
   before(:each) do
+    I18n.reload!
+    I18n.backend.store_translations(:en, {}) if defined? translations
     LHC.config.placeholder(:datastore, datastore)
     class Record < LHS::Record
       endpoint ':datastore/:campaign_id/feedbacks'

--- a/spec/item/warning_codes_spec.rb
+++ b/spec/item/warning_codes_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  context 'error codes' do
+    before(:each) do
+      I18n.reload!
+      I18n.backend.store_translations(:en, YAML.safe_load(translation)) if translation.present?
+      class Record < LHS::Record
+        endpoint 'http://datastore/records'
+      end
+    end
+
+    let(:translation) do
+      %q{
+        lhs:
+          warnings:
+            fallback_message: 'This value is problematic'
+      }
+    end
+
+    it 'provides error codes along side with translated messages' do
+      stub_request(:post, 'http://datastore/records')
+        .to_return(body: {
+          field_warnings: [{
+            code: 'UNSUPPORTED_PROPERTY_VALUE',
+            path: ['gender'],
+            message: 'The property value is unsupported.'
+          }, {
+            code: 'INCOMPLETE_PROPERTY_VALUE',
+            path: ['gender'],
+            message: 'The property value is incomplete. It misses some data'
+          }, {
+            code: 'INCOMPLETE_PROPERTY_VALUE',
+            path: ['contract', 'entry_id'],
+            message: 'The property value is incomplete. It misses some data'
+          }]
+        }.to_json)
+      record = Record.create
+      expect(record.warnings.messages['gender']).to eq(
+        ['This value is problematic', 'This value is problematic']
+      )
+      expect(record.warnings.codes['gender']).to eq(
+        ['UNSUPPORTED_PROPERTY_VALUE', 'INCOMPLETE_PROPERTY_VALUE']
+      )
+      expect(record.warnings.messages['contract.entry_id']).to eq(
+        ['This value is problematic']
+      )
+      expect(record.warnings.codes['contract.entry_id']).to eq(
+        ['INCOMPLETE_PROPERTY_VALUE']
+      )
+    end
+  end
+end


### PR DESCRIPTION
_MINOR_

As `errors.messages` is already translated, it's inconvenient to have logic testing error codes.

Here we introduce `errors.codes` which always returns just the codes, so you can attach logic to it.

```ruby
user.errors.messages # {:email=>["Translated error message that this value is required"]}
user.errors.codes # {:email=>["REQUIRED_PROPERTY_VALUE"]}
```