### PR TITLE
Record Relations: has_many

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,6 @@ Style/EmptyLinesAroundBlockBody:
 
 RSpec/MultipleExpectations:
   Enabled: false
+
+Naming/PredicateName:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ After fetching [single](#find-single-records) or [multiple](#find-multiple-recor
 
 Even though, nested data is automatically casted when accessed, see: [Nested records](#nested-records), sometimes api's don't provide dedicated endpoints to retrive these records.
 
-As those records also don't have href's in this case, nested records can not be casted automatically.
+As those records also don't have an href, nested records can not be casted automatically, when accessed.
 
 Those kind of relations, you can still configure manually:
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,36 @@ After fetching [single](#find-single-records) or [multiple](#find-multiple-recor
   record.parent == records # true
 ```
 
+## Relations
+
+Even though, nested data is automatically casted when accessed, see: [Nested records](#nested-records), sometimes api's don't provide dedicated endpoints to retrive these records.
+
+As those records also don't have href's in this case, nested records can not be casted automatically.
+
+Those kind of relations, you can still configure manually:
+
+```ruby
+
+class Location < LHS::Record
+  
+  endpoint 'http://uberall/locations/:id'
+
+  has_many :listings
+
+end
+
+class Listing < LHS::Record
+  
+  def supported?
+    type == 'SUPPORTED'
+  end
+end
+
+Location.find(1).listings.first.supported? # true
+
+```
+
+
 ## Request based options
 
 You can apply options to the request chain. Those options will be forwarded to the request perfomed by the chain/query.
@@ -643,7 +673,7 @@ class LocalEntry < LHS::Record
 end
 ```
 
-### Nested records
+## Nested records
 
 Nested records (in nested data) are automaticaly casted when the href matches any defined endpoint of any LHS::Record.
 

--- a/lib/lhs/concerns/data/becomes.rb
+++ b/lib/lhs/concerns/data/becomes.rb
@@ -1,6 +1,6 @@
 require 'active_support'
 
-class LHS::Item < LHS::Proxy
+class LHS::Data
 
   module Becomes
     extend ActiveSupport::Concern

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -77,7 +77,7 @@ class LHS::Proxy
       data.errors = LHS::Problems::Nested::Errors.new(errors, name) if errors.any?
       data.warnings = LHS::Problems::Nested::Warnings.new(warnings, name) if warnings.any?
       return record.new(data) if record && !value.is_a?(LHS::Record)
-      return data.becomes(_record.relations[name][:record_class_name].constantize) if _record && _record.relations[name]
+      return data.becomes(_record._relations[name][:record_class_name].constantize) if _record && _record._relations[name]
       data
     end
 

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -67,8 +67,9 @@ class LHS::Proxy
       wrap_return(collection, record, name)
     end
 
-    # Wraps with record and adds nested errors/warnings to data,
-    # if errors are existing
+    # Wraps the return value with a record class.
+    # Adds errors and warnings if existing.
+    # Returns plain data if no record class was found.
     def wrap_return(value, record, name, args = nil)
       name = args.first if name == :[]
       return value unless worth_wrapping?(value)
@@ -76,6 +77,7 @@ class LHS::Proxy
       data.errors = LHS::Problems::Nested::Errors.new(errors, name) if errors.any?
       data.warnings = LHS::Problems::Nested::Warnings.new(warnings, name) if warnings.any?
       return record.new(data) if record && !value.is_a?(LHS::Record)
+      return data.becomes(_record.relations[name][:record_class_name].constantize) if _record && _record.relations[name]
       data
     end
 

--- a/lib/lhs/concerns/record/relations.rb
+++ b/lib/lhs/concerns/record/relations.rb
@@ -1,0 +1,20 @@
+require 'active_support'
+require 'active_support/core_ext/class/attribute'
+
+class LHS::Record
+
+  module Relations
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :relations
+      self.relations = {}
+    end
+
+    module ClassMethods
+      def has_many(name)
+        relations[name] = { record_class_name: name.to_s.singularize.classify }
+      end
+    end
+  end
+end

--- a/lib/lhs/concerns/record/relations.rb
+++ b/lib/lhs/concerns/record/relations.rb
@@ -7,13 +7,13 @@ class LHS::Record
     extend ActiveSupport::Concern
 
     included do
-      class_attribute :relations
-      self.relations = {}
+      class_attribute :_relations
+      self._relations = {}
     end
 
     module ClassMethods
       def has_many(name)
-        relations[name] = { record_class_name: name.to_s.singularize.classify }
+        _relations[name] = { record_class_name: name.to_s.singularize.classify }
       end
     end
   end

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -1,5 +1,7 @@
 # Data provides functionalities to accesses information
 class LHS::Data
+  autoload :Becomes,
+    'lhs/concerns/data/becomes'
   autoload :Equality,
     'lhs/concerns/data/equality'
   autoload :Json,
@@ -7,6 +9,7 @@ class LHS::Data
   autoload :ToHash,
     'lhs/concerns/data/to_hash'
 
+  include Becomes
   include Equality
   include Json
   include ToHash

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -1,8 +1,6 @@
 # An item is a concrete record.
 # It can be part of another proxy like collection.
 class LHS::Item < LHS::Proxy
-  autoload :Becomes,
-    'lhs/concerns/item/becomes'
   autoload :Destroy,
     'lhs/concerns/item/destroy'
   autoload :Save,
@@ -12,7 +10,6 @@ class LHS::Item < LHS::Proxy
   autoload :Validation,
     'lhs/concerns/item/validation'
 
-  include Becomes
   include Create
   include Destroy
   include Save

--- a/lib/lhs/proxy.rb
+++ b/lib/lhs/proxy.rb
@@ -17,7 +17,7 @@ class LHS::Proxy
 
   # prevent clashing with attributes of underlying data
   attr_accessor :_data, :_loaded
-  delegate :_record, to: :_data, allow_nil: true
+  delegate :_record, :becomes, to: :_data, allow_nil: true
 
   def initialize(data)
     self._data = data

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -27,6 +27,8 @@ class LHS::Record
     'lhs/concerns/record/pagination'
   autoload :Request,
     'lhs/concerns/record/request'
+  autoload :Relations,
+    'lhs/concerns/record/relations'
   autoload :Scope,
     'lhs/concerns/record/scope'
 
@@ -52,6 +54,7 @@ class LHS::Record
   include Model
   include Pagination
   include Request
+  include Relations
   include RequestCycleCache
   include Scope
 

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -58,7 +58,7 @@ class LHS::Record
   include RequestCycleCache
   include Scope
 
-  delegate :_proxy, :_endpoint, :merge_raw!, :select, to: :_data
+  delegate :_proxy, :_endpoint, :merge_raw!, :select, :becomes, to: :_data
 
   def initialize(data = nil, apply_customer_setters = true)
     data = LHS::Data.new({}, nil, self.class) unless data

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '14.5.0'
+  VERSION = '14.6.0'
 end

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -22,7 +22,7 @@ describe LHS::Record do
 
     it 'casts the relation into the correct type' do
       stub_request(:get, 'http://uberall/locations/1')
-        .to_return(body:{
+        .to_return(body: {
           listings: [{
             directory: { name: 'Instagram' }
           }]

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  before(:each) do
+    class Location < LHS::Record
+      endpoint 'http://uberall/locations'
+      endpoint 'http://uberall/locations/:id'
+      has_many :listings
+    end
+
+    class Listing < LHS::Record
+
+      def supported?
+        true
+      end
+    end
+  end
+
+  context 'has_many' do
+    let(:location) { Location.find(1) }
+    let(:listing) { location.listings.first }
+
+    it 'casts the relation into the correct type' do
+      stub_request(:get, 'http://uberall/locations/1')
+        .to_return(body:{
+          listings: [{
+            directory: { name: 'Instagram' }
+          }]
+        }.to_json)
+      expect(listing).to be_kind_of(Listing)
+      expect(listing.supported?).to eq true
+    end
+  end
+end

--- a/spec/support/cleanup.rb
+++ b/spec/support/cleanup.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
     LHC::Config.instance._cleanup
     LHS::Record::Endpoints.all = {}
     LHS::Record::CHILDREN.each do |child|
-      child.endpoints = [] if !child.name['LHS']
+      child.endpoints = [] if !child.name['LHS'] && defined?(child.endpoints)
       child.configuration({}) if !child.name['LHS']
     end
   end


### PR DESCRIPTION
_MINOR_

## Relations

Even though, nested data is usually automatically casted when accessed, see: [Nested records](#nested-records), sometimes api's don't provide dedicated endpoints to retrieve these records.

As those records also don't have an href, nested records can not be casted automatically, when accessed.

Those kind of relations, you can still configure manually:

```ruby

class Location < LHS::Record
  
  endpoint 'http://uberall/locations/:id'

  has_many :listings

end

class Listing < LHS::Record
  
  def supported?
    type == 'SUPPORTED'
  end
end

Location.find(1).listings.first.supported? # true

```