### PR TITLE
Preserving Hierarchy Fix

### DIFF
--- a/lib/lhs/concerns/data/becomes.rb
+++ b/lib/lhs/concerns/data/becomes.rb
@@ -6,7 +6,7 @@ class LHS::Data
     extend ActiveSupport::Concern
 
     def becomes(klass)
-      klass.new(_raw)
+      klass.new(LHS::Data.new(_raw, _parent, klass))
     end
   end
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '14.6.0'
+  VERSION = '14.6.1'
 end

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -20,15 +20,23 @@ describe LHS::Record do
     let(:location) { Location.find(1) }
     let(:listing) { location.listings.first }
 
-    it 'casts the relation into the correct type' do
+    before(:each) do
       stub_request(:get, 'http://uberall/locations/1')
         .to_return(body: {
           listings: [{
             directory: { name: 'Instagram' }
           }]
         }.to_json)
+    end
+
+    it 'casts the relation into the correct type' do
       expect(listing).to be_kind_of(Listing)
       expect(listing.supported?).to eq true
+    end
+
+    it 'keeps hirachy when casting it to another class on access' do
+      expect(listing._root._raw).to eq location._raw
+      expect(listing.parent.parent._raw).to eq location._raw
     end
   end
 end


### PR DESCRIPTION
_PATCH_

When casting data on access (becomes), the data hierarchy was not preserved.

## Before

```ruby
location.listings.first.parent # nil
```

## Now (fixed)

``` ruby
location.listings.first.parent # listings
location.listings.first.parent.parent # location
```