### PR TITLE
Fix require lhs

### DIFF
--- a/lib/lhs/pagination/base.rb
+++ b/lib/lhs/pagination/base.rb
@@ -1,3 +1,5 @@
+require 'active_support/core_ext/module/delegation'
+
 # Pagination is used to navigate paginateable collections
 module LHS::Pagination
   class Base

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '14.6.1'
+  VERSION = '14.6.2'
 end

--- a/spec/require_lhs_spec.rb
+++ b/spec/require_lhs_spec.rb
@@ -1,9 +1,9 @@
 require 'pry'
 require 'webmock/rspec'
 
-describe 'Require LHS' do
-  context 'request without rails' do
-    it 'does have deep_merge dependency met' do
+describe 'LHS' do
+  context 'when requiring lhs' do
+    it 'does not raise an exception' do
       expect { require 'lhs' }.not_to raise_error
     end
   end

--- a/spec/require_lhs_spec.rb
+++ b/spec/require_lhs_spec.rb
@@ -1,6 +1,3 @@
-require 'pry'
-require 'webmock/rspec'
-
 describe 'LHS' do
   context 'when requiring lhs' do
     it 'does not raise an exception' do

--- a/spec/require_lhs_spec.rb
+++ b/spec/require_lhs_spec.rb
@@ -1,0 +1,10 @@
+require 'pry'
+require 'webmock/rspec'
+
+describe 'Require LHS' do
+  context 'request without rails' do
+    it 'does have deep_merge dependency met' do
+      expect { require 'lhs' }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
#PATCH

Issue: using `require 'lhs'` in a non rails app cause some issues with `delegate`.
`NoMethodError: undefined method `delegate' for LHS::Pagination::Base:Class`

This solves this specific use case.
