### PR TITLE
Add :compact to Internal Collection

### DIFF
--- a/lib/lhs/concerns/collection/internal_collection.rb
+++ b/lib/lhs/concerns/collection/internal_collection.rb
@@ -12,7 +12,7 @@ class LHS::Collection < LHS::Proxy
 
       attr_accessor :raw
       delegate :length, :size, :last, :sample, :[], :present?, :blank?, :empty?,
-               :<<, :push, to: :raw
+               :<<, :push, :compact, to: :raw
 
       def initialize(raw, parent, record)
         self.raw = raw

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '14.6.2'
+  VERSION = '14.6.3'
 end

--- a/spec/collection/delegate_spec.rb
+++ b/spec/collection/delegate_spec.rb
@@ -10,7 +10,7 @@ describe LHS::Collection do
   end
 
   context 'delegates methods to raw' do
-    %w(present? blank? empty?).each do |method|
+    %w(length size last sample present? blank? empty? compact).each do |method|
       it "delegates #{method} to raw" do
         expect(collection.send(method.to_sym)).not_to be_nil
       end


### PR DESCRIPTION
Give internalCollection a more array'y feel, by having it support `:compact`