### PR TITLE
Fix exclude?

### DIFF
--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -64,7 +64,7 @@ class LHS::Collection < LHS::Proxy
 
   def respond_to_missing?(name, _include_all = false)
     # We accept every message that does not belong to set of keywords and is not a setter
-    BLACKLISTED_KEYWORDS.exclude?(name.to_s) && !name.to_s[/=$/]
+    !BLACKLISTED_KEYWORDS.include?(name.to_s) && !name.to_s[/=$/]
   end
 
   private

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -37,7 +37,7 @@ class LHS::Item < LHS::Proxy
 
   def respond_to_missing?(name, _include_all = false)
     # We accept every message that does not belong to set of keywords
-    BLACKLISTED_KEYWORDS.include?(name.to_s)
+    !BLACKLISTED_KEYWORDS.include?(name.to_s)
   end
 
   def unwrap_nested_item

--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -1,6 +1,7 @@
 # An item is a concrete record.
 # It can be part of another proxy like collection.
 class LHS::Item < LHS::Proxy
+
   autoload :Destroy,
     'lhs/concerns/item/destroy'
   autoload :Save,
@@ -36,7 +37,7 @@ class LHS::Item < LHS::Proxy
 
   def respond_to_missing?(name, _include_all = false)
     # We accept every message that does not belong to set of keywords
-    BLACKLISTED_KEYWORDS.exclude?(name.to_s)
+    BLACKLISTED_KEYWORDS.include?(name.to_s)
   end
 
   def unwrap_nested_item

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '14.6.3'
+  VERSION = '14.6.4'
 end

--- a/spec/item/blacklisted_keywords_spec.rb
+++ b/spec/item/blacklisted_keywords_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'lhs'
+
+describe LHS::Item do
+
+  before(:each) do
+    class Record < LHS::Record
+      endpoint 'http://datastore/v2/records'
+    end
+  end
+
+  context 'requires active support when dealing with Item' do
+
+    it "does not raise an error" do
+      stub_request(:get, "http://datastore/v2/records?color=blue")
+        .to_return(
+          body: {
+            items: [{ name: 'Steve' }]
+          }.to_json
+        )
+      Record.where(color: :blue).map do |record|
+        record.name
+      end
+    end
+  end
+end

--- a/spec/item/blacklisted_keywords_spec.rb
+++ b/spec/item/blacklisted_keywords_spec.rb
@@ -18,8 +18,10 @@ describe LHS::Item do
             items: [{ name: 'Steve' }]
           }.to_json
         )
-      Record.where(color: :blue).map do |record|
-        record.name
+      Record.where(color: :blue).each do |record|
+        expect(record.respond_to_missing?(:new)).to eq false
+        expect(record.respond_to_missing?(:proxy_association)).to eq false
+        expect(record.respond_to_missing?(:name)).to eq true
       end
     end
   end


### PR DESCRIPTION
`exclude?` raises exceptions when used with none rails/activesupport applications.

Currently I've problems with `lcl`

```
/Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/item.rb:39:in `respond_to_missing?': undefined method `exclude?' for ["new", "proxy_association"]:Array (NoMethodError)
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/data.rb:87:in `method_missing'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/record.rb:85:in `respond_to_missing?'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.4/lib/active_support/core_ext/object/try.rb:6:in `respond_to?'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/activesupport-5.1.4/lib/active_support/core_ext/object/try.rb:6:in `try'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/concerns/record/request.rb:223:in `load_and_merge_remaining_objects!'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/concerns/record/request.rb:26:in `single_request_load_and_merge_remaining_objects!'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/concerns/record/request.rb:512:in `single_request'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/concerns/record/request.rb:18:in `request'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/concerns/record/chainable.rb:315:in `resolve'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/lhs-14.6.3/lib/lhs/concerns/record/chainable.rb:305:in `method_missing'
	from /Users/Sebastian/Work/Extern/local/lcl/lib/lcl/actions/gem.rb:55:in `print_apps_using'
	from /Users/Sebastian/Work/Extern/local/lcl/lib/lcl/actions/gem.rb:15:in `default_action'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/invocation.rb:115:in `invoke'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor.rb:238:in `block in subcommand'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	from /Users/Sebastian/Work/Extern/local/lcl/exe/lcl:4:in `<top (required)>'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/bin/lcl:23:in `load'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/bin/lcl:23:in `<main>'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `eval'
	from /Users/Sebastian/.rvm/gems/ruby-2.4.1/bin/ruby_executable_hooks:15:in `<main>'
```

Prefered to replace them with `!include?` over requiring libraries. Back to the roots/ or back to native ruby.