### PR TITLE
! fetch for data item

### DIFF
--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -8,7 +8,7 @@ class LHS::Proxy
     # FIXME: Extend the set of keywords
     BLACKLISTED_KEYWORDS = %w(new proxy_association)
 
-    delegate :dig, to: :_raw, allow_nil: true
+    delegate :dig, :fetch, to: :_raw, allow_nil: true
 
     private
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '14.6.4'
+  VERSION = '14.6.5'
 end

--- a/spec/item/fetch_spec.rb
+++ b/spec/item/fetch_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe LHS::Item do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint ':datastore/records'
+    end
+  end
+
+  let(:json) do
+    {
+      local_entry_id: 'ABC123'
+    }
+  end
+
+  let(:item) do
+    LHS::Data.new(json, nil, Record)
+  end
+
+  it 'is possible to fetch data' do
+    expect(
+      item.fetch(:local_entry_id)
+    ).to eq 'ABC123'
+  end
+
+  context 'empty data' do
+    let(:json) do
+      {}
+    end
+
+    it 'is possible to get a default when fetched data is nil' do
+      expect(
+        item.fetch(:local_entry_id, 'DEFAULT')
+      ).to eq 'DEFAULT'
+    end
+  end
+end


### PR DESCRIPTION
_PATCH_

`.fetch` was not forwarded to raw for all lhs data (item) objects.

## BEFORE

```
place = Place.find(123) # raw: {id: '123'}
place.fetch(:id) # nil
```

## NOW

```
place = Place.find(123) # raw: {id: '123'}
place.fetch(:id) # 123
```