### PR TITLE
Fix find_in_batches

### DIFF
--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -23,8 +23,8 @@ class LHS::Record
         batch_size = options[:batch_size] || LHS::Pagination::Base::DEFAULT_LIMIT
         params = options[:params] || {}
         loop do # as suggested by Matz
-          limit_param_name = limit_key(:parameter).kind_of?(Array) ? limit_key(:parameter).last : limit_key(:parameter)
-          pagination_param_name = pagination_key(:parameter).kind_of?(Array) ? pagination_key(:parameter).last : pagination_key(:parameter)
+          limit_param_name = limit_key(:parameter).is_a?(Array) ? limit_key(:parameter).last : limit_key(:parameter)
+          pagination_param_name = pagination_key(:parameter).is_a?(Array) ? pagination_key(:parameter).last : pagination_key(:parameter)
 
           data = request(params: params.merge(limit_param_name => batch_size, pagination_param_name => start))
           batch_size = data._raw.dig(*limit_key(:parameter))

--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -23,12 +23,9 @@ class LHS::Record
         batch_size = options[:batch_size] || LHS::Pagination::Base::DEFAULT_LIMIT
         params = options[:params] || {}
         loop do # as suggested by Matz
-          limit_param_name = limit_key(:parameter).is_a?(Array) ? limit_key(:parameter).last : limit_key(:parameter)
-          pagination_param_name = pagination_key(:parameter).is_a?(Array) ? pagination_key(:parameter).last : pagination_key(:parameter)
-
-          data = request(params: params.merge(limit_param_name => batch_size, pagination_param_name => start))
-          batch_size = data._raw.dig(*limit_key(:parameter))
-          left = data._raw.dig(*total_key).to_i - data._raw.dig(*pagination_key(:parameter)).to_i - data._raw.dig(*limit_key(:parameter)).to_i
+          data = request(params: params.merge(limit_key(:parameter) => batch_size, pagination_key(:parameter) => start))
+          batch_size = data._raw.dig(*limit_key(:body))
+          left = data._raw.dig(*total_key).to_i - data._raw.dig(*pagination_key(:body)).to_i - data._raw.dig(*limit_key(:body)).to_i
           yield new(data)
           break if left <= 0
           start += batch_size

--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -23,9 +23,12 @@ class LHS::Record
         batch_size = options[:batch_size] || LHS::Pagination::Base::DEFAULT_LIMIT
         params = options[:params] || {}
         loop do # as suggested by Matz
-          data = request(params: params.merge(limit_key(:parameter) => batch_size, pagination_key(:parameter) => start))
-          batch_size = data._raw[limit_key(:parameter)]
-          left = data._raw.dig(*total_key).to_i - data._raw[pagination_key(:parameter)].to_i - data._raw[limit_key(:paramter)].to_i
+          limit_param_name = limit_key(:parameter).kind_of?(Array) ? limit_key(:parameter).last : limit_key(:parameter)
+          pagination_param_name = pagination_key(:parameter).kind_of?(Array) ? pagination_key(:parameter).last : pagination_key(:parameter)
+
+          data = request(params: params.merge(limit_param_name => batch_size, pagination_param_name => start))
+          batch_size = data._raw.dig(*limit_key(:parameter))
+          left = data._raw.dig(*total_key).to_i - data._raw.dig(*pagination_key(:parameter)).to_i - data._raw.dig(*limit_key(:parameter)).to_i
           yield new(data)
           break if left <= 0
           start += batch_size

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.0.1'
+  VERSION = '15.0.2'
 end


### PR DESCRIPTION
This method could not deal with pagination and limit key names that were nested. This fixes that problem.