### PR TITLE
Fix find in parallel

### DIFF
--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -18,8 +18,13 @@ class LHS::Record
           else
             find_by_id(args, options)
           end
-        return data if data && (data.is_a?(Array) || !data._record || data.collection?)
-        data ? data._record.new(data.unwrap_nested_item) : nil
+        return nil if data.nil?
+        return data if !data._record
+        if data.collection?
+          data.map { |record| data._record.new(record.unwrap_nested_item) }
+        else
+          data._record.new(data.unwrap_nested_item)
+        end
       end
 
       private

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.0.2'
+  VERSION = '15.1.0'
 end

--- a/spec/record/find_in_parallel_spec.rb
+++ b/spec/record/find_in_parallel_spec.rb
@@ -36,4 +36,30 @@ describe LHS::Record do
       expect(data[1].name).to eq 'unknown'
     end
   end
+
+  context 'find in parallel with extra methods' do
+    before do
+      class Record < LHS::Record
+        endpoint 'http://datastore/records/{id}'
+
+        def identifier
+          123456
+        end
+      end
+
+      stub_request(:get, "http://datastore/records/1").to_return(status: 200, body: { id: 1 }.to_json)
+      stub_request(:get, "http://datastore/records/2").to_return(status: 200, body: { id: 2 }.to_json)
+      stub_request(:get, "http://datastore/records/3").to_return(status: 200, body: { id: 3 }.to_json)
+    end
+
+    it 'finds single record in parallel' do
+      data = Record.find([1])
+      expect(data[0].identifier).to eq 123456
+    end
+
+    it 'finds records in parallel' do
+      data = Record.find([1, 2, 3])
+      expect(data[0].identifier).to eq 123456
+    end
+  end
 end


### PR DESCRIPTION
Fixes the case when you use `find` with more than one `id` and want it to be your record class.