### PR TITLE
Make it LHC 9 compatible

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.3.0'
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'lhc', '>= 7.0.1'
+  s.add_dependency 'lhc', '~> 9.1.1'
   s.add_dependency 'activesupport', '> 4.2'
   s.add_dependency 'activemodel'
 

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -26,7 +26,7 @@ class LHS::Item < LHS::Proxy
     private
 
     def apply_default_creation_options(options, url, data)
-      options = options.merge(method: :post, url: url, body: data.to_json)
+      options = options.merge(method: :post, url: url, body: data)
       options[:headers] ||= {}
       options[:headers].merge!('Content-Type' => 'application/json')
       options

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -33,7 +33,7 @@ class LHS::Item < LHS::Proxy
         options.merge(
           method: options.fetch(:method, :post),
           url: url,
-          body: data_sent.to_json,
+          body: data_sent,
           headers: { 'Content-Type' => 'application/json' }
         )
       )

--- a/lib/lhs/concerns/item/validation.rb
+++ b/lib/lhs/concerns/item/validation.rb
@@ -43,7 +43,7 @@ class LHS::Item < LHS::Proxy
           url: url,
           method: :post,
           params: params,
-          body: _data.to_json,
+          body: _data,
           headers: { 'Content-Type' => 'application/json' }
         )
       )

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.1.1'
+  VERSION = '15.2.0'
 end

--- a/spec/record/options_spec.rb
+++ b/spec/record/options_spec.rb
@@ -61,7 +61,7 @@ describe LHS::Record do
     it 'is also applicable to create' do
       stub_request(:post, 'http://datastore/v2/records').to_return(body: {}.to_json)
       expect(LHC).to receive(:request)
-        .with(options.merge(method: :post, url: "http://datastore/v2/records", body: {name: 'Steve'}, headers: { 'Content-Type' => 'application/json' }))
+        .with(options.merge(method: :post, url: "http://datastore/v2/records", body: { name: 'Steve' }, headers: { 'Content-Type' => 'application/json' }))
         .and_call_original
       Record.options(options).create(name: 'Steve')
     end

--- a/spec/record/options_spec.rb
+++ b/spec/record/options_spec.rb
@@ -61,7 +61,7 @@ describe LHS::Record do
     it 'is also applicable to create' do
       stub_request(:post, 'http://datastore/v2/records').to_return(body: {}.to_json)
       expect(LHC).to receive(:request)
-        .with(options.merge(method: :post, url: "http://datastore/v2/records", body: "{\"name\":\"Steve\"}", headers: { 'Content-Type' => 'application/json' }))
+        .with(options.merge(method: :post, url: "http://datastore/v2/records", body: {name: 'Steve'}, headers: { 'Content-Type' => 'application/json' }))
         .and_call_original
       Record.options(options).create(name: 'Steve')
     end
@@ -76,7 +76,7 @@ describe LHS::Record do
         before(:each) do
           stub_request(:post, 'http://datastore/v2/records/123').to_return(body: {}.to_json)
           expect(LHC).to receive(:request)
-            .with(options.merge(method: :post, url: "http://datastore/v2/records/123", body: "{\"href\":\"http://datastore/v2/records/123\"}", headers: { "Content-Type" => "application/json" }))
+            .with(options.merge(method: :post, url: "http://datastore/v2/records/123", body: { href: 'http://datastore/v2/records/123' }, headers: { "Content-Type" => "application/json" }))
             .and_call_original
         end
 
@@ -117,8 +117,9 @@ describe LHS::Record do
       context 'update' do
         before(:each) do
           stub_request(:post, "http://datastore/v2/records/123").to_return(body: {}.to_json)
+          body = LHS::Data.new({ href: 'http://datastore/v2/records/123', name: 'steve' }, nil, Record)
           expect(LHC).to receive(:request)
-            .with(options.merge(method: :post, url: "http://datastore/v2/records/123", body: "{\"href\":\"http://datastore/v2/records/123\",\"name\":\"steve\"}", headers: { "Content-Type" => "application/json" }))
+            .with(options.merge(method: :post, url: "http://datastore/v2/records/123", body: body, headers: { "Content-Type" => "application/json" }))
             .and_call_original
         end
 
@@ -142,8 +143,9 @@ describe LHS::Record do
       context 'valid' do
         before(:each) do
           stub_request(:post, 'http://datastore/v2/records?persist=false').to_return(body: {}.to_json)
+          body = LHS::Data.new({ href: 'http://datastore/v2/records/123' }, nil, Record)
           expect(LHC).to receive(:request)
-            .with(options.merge(url: '{+datastore}/records', method: :post, params: { persist: false }, body: "{\"href\":\"http://datastore/v2/records/123\"}", headers: { "Content-Type" => "application/json" }))
+            .with(options.merge(url: '{+datastore}/records', method: :post, params: { persist: false }, body: body, headers: { "Content-Type" => "application/json" }))
             .and_call_original
         end
 


### PR DESCRIPTION
_MINOR_

Makes LHS LHC 9 compatible.

See breaking change LHC 9: https://github.com/local-ch/lhc/releases/tag/v9.0.0

Basically: 

- Getting rid of calling `.to_json` everytime we provide a request body, as lhc takes care of formats
- Fix some test stubs