### PR TITLE
Update Request Cycle Interceptor to new LHC format

### DIFF
--- a/lib/lhs/concerns/record/request_cycle_cache/interceptor.rb
+++ b/lib/lhs/concerns/record/request_cycle_cache/interceptor.rb
@@ -10,7 +10,7 @@ class LHS::Record
       VERSION = 1
       CACHED_METHODS = [:get].freeze
 
-      def before_request
+      def before_request(request)
         request.options = request.options.merge({
           cache: {
             expires_in: 5.minutes,

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.2.1'
+  VERSION = '15.2.2'
 end


### PR DESCRIPTION
The format for Interceptor hooks has changed in newer versions of LHC, this brings the Request Cycle Cache up to date.