### PR TITLE
! fix nested includes

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -267,7 +267,7 @@ class LHS::Record
 
       def load_and_merge_set_of_paginated_collections!(data, options)
         options_for_this_batch = []
-        options.each_with_index do |_, index|
+        options.compact.each_with_index do |_, index|
           record = data[index]._record
           pagination = record.pagination(data[index])
           next if pagination.pages_left.zero?

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.2.1'
+  VERSION = '15.2.2'
 end


### PR DESCRIPTION
Fixes an error with nested optional includes.

Suppose the following set of requests:

```
=> http://datastore/favorites

{
  items: [{
    href: "http://datastore/favorites/1",
    place: {
      href: "http://datastore/places/1"
    }
  }, {
    href: "http://datastore/favorite/2",
    place: {
      href: "http://datastore/places/2"
    }
  }],
  total: 2,
  offset: 0,
  limit: 100
}
```

```
=> http://datastore/places/1

{
  href: "http://datastore/places/1",
  name: 'Place 1',
  contracts: {
    href: "http://datastore/places/1/contracts"
  }
}
```

```
=> http://datastore/places/1/contracts

{
  items: [{
    href: "http://datastore/places/1/contracts/1",
    name: 'Contract 1'
  }],
  total: 1,
  offset: 0,
  limit: 10
}
```

```
=> http://datastore/places/2

{
  href: "http://datastore/places/2",
  name: 'Place 2'
}
```

Notice how `Place 2` does not have any contracts.

If `contracts` were added to nested `places` via `includes_all` :
```
Favorite.includes(:place).includes_all(place: :contracts)
```

an exception would be raised.

This PR fixes this.