### PR TITLE
Avoid nil data elements

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -267,14 +267,18 @@ class LHS::Record
 
       def load_and_merge_set_of_paginated_collections!(data, options)
         options_for_this_batch = []
+        data_record = data._record
+        data = data.compact
         options.compact.each_with_index do |_, index|
           record = data[index]._record
           pagination = record.pagination(data[index])
           next if pagination.pages_left.zero?
           options_for_this_batch.push(options_for_next_batch(record, pagination, options[index], data[index]))
         end
-        data._record.request(options_for_this_batch.flatten).each do |batch_data|
-          merge_batch_data_with_parent!(batch_data, batch_data._request.options[:parent_data])
+        if data_record.present?
+          data_record.request(options_for_this_batch.flatten).each do |batch_data|
+            merge_batch_data_with_parent!(batch_data, batch_data._request.options[:parent_data])
+          end
         end
       end
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.2.2-favorites.1'
+  VERSION = '15.2.3-favorites.1'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.2.2'
+  VERSION = '15.2.2-favorites.1'
 end

--- a/spec/concerns/record/request_spec.rb
+++ b/spec/concerns/record/request_spec.rb
@@ -89,7 +89,7 @@ describe LHS::Record::Request do
           all: true,
           auth: { bearer: 'xxx' },
           params: { limit: 100 }
-        },
+        }
       ]
     end
 
@@ -97,7 +97,7 @@ describe LHS::Record::Request do
       [
         LHS::Record.new,
         nil,
-        LHS::Record.new,
+        LHS::Record.new
       ]
     end
 

--- a/spec/concerns/record/request_spec.rb
+++ b/spec/concerns/record/request_spec.rb
@@ -73,4 +73,28 @@ describe LHS::Record::Request do
                            params: { limit: 100 })
     end
   end
+
+  describe 'load_and_merge_set_of_paginated_collections!' do
+    let(:options) do
+      [
+        {
+          url: 'http://localhost:3000/test/resource?abc=def&limit=1&offset=3&test=1',
+          all: true,
+          auth: { bearer: 'xxx' },
+          params: { limit: 100 }
+        }
+      ]
+    end
+    let(:data) do
+      [
+        LHS::Record.new,
+        nil,
+        LHS::Record.new,
+      ]
+    end
+
+    it 'returns even if data has nil elements' do
+      expect(subject.send(:load_and_merge_set_of_paginated_collections!, data, options)).to eq('asdf')
+    end
+  end
 end

--- a/spec/concerns/record/request_spec.rb
+++ b/spec/concerns/record/request_spec.rb
@@ -82,10 +82,18 @@ describe LHS::Record::Request do
           all: true,
           auth: { bearer: 'xxx' },
           params: { limit: 100 }
-        }
+        },
+        nil,
+        {
+          url: 'http://localhost:3000/test/resource?abc=def&limit=1&offset=3&test=3',
+          all: true,
+          auth: { bearer: 'xxx' },
+          params: { limit: 100 }
+        },
       ]
     end
-    let(:data) do
+
+    let(:data_array) do
       [
         LHS::Record.new,
         nil,
@@ -93,8 +101,12 @@ describe LHS::Record::Request do
       ]
     end
 
-    it 'returns even if data has nil elements' do
-      expect(subject.send(:load_and_merge_set_of_paginated_collections!, data, options)).to eq('asdf')
+    let(:data) do
+      LHS::Record.new(data_array)
+    end
+
+    it 'does not raise an error when data has nil objects' do
+      expect(subject.send(:load_and_merge_set_of_paginated_collections!, data, options)).to_not be_nil
     end
   end
 end


### PR DESCRIPTION
Error raised when data includes nil elements

# Before
<img width="1086" alt="screen shot 2018-05-25 at 18 24 22" src="https://user-images.githubusercontent.com/954367/40555294-e3b5d8be-6048-11e8-9a9e-94d239b9ecb9.png">

# After
<img width="881" alt="screen shot 2018-05-25 at 18 25 04" src="https://user-images.githubusercontent.com/954367/40555324-fc02e18c-6048-11e8-8e23-769706bbd205.png">

