### PR TITLE
Fix lhc dependency

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.requirements << 'Ruby >= 2.3.0'
   s.required_ruby_version = '>= 2.3.0'
 
-  s.add_dependency 'lhc', '~> 9.1.2'
+  s.add_dependency 'lhc', '~> 9.2'
   s.add_dependency 'activesupport', '> 4.2'
   s.add_dependency 'activemodel'
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.3.1.pre.fixlhc.1'
+  VERSION = '15.3.1'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.3.0'
+  VERSION = '15.3.1.pre.fixlhc.1'
 end


### PR DESCRIPTION
The LHC dependency was to strict.

This PR bumps to current LHC and only requires the MAJOR version as requirement.