### PR TITLE
Single items do not respond to to_ary

### DIFF
--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -28,6 +28,14 @@ class LHS::Item < LHS::Proxy
     true
   end
 
+  def respond_to?(sym, include_all = false)
+    if sym == :to_ary
+      false
+    else
+      super(sym, include_all)
+    end
+  end
+
   protected
 
   def method_missing(name, *args, &_block)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.3.1'
+  VERSION = '15.3.2'
 end

--- a/spec/collection/to_ary_spec.rb
+++ b/spec/collection/to_ary_spec.rb
@@ -30,5 +30,9 @@ describe LHS::Collection do
       expect(subject[0]).to be_kind_of Record
       expect(subject[0].name).to eq 'Steve'
     end
+
+    it 'responds to to_ary' do
+      expect(subject.respond_to?(:to_ary)).to eq true
+    end
   end
 end

--- a/spec/data/to_ary_spec.rb
+++ b/spec/data/to_ary_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+describe LHS::Data do
+  before(:each) do
+    class Record < LHS::Record
+      endpoint '{+datastore}/v2/{campaign_id}/feedbacks'
+      endpoint '{+datastore}/v2/feedbacks'
+    end
+  end
+
+  let(:json) do
+    load_json(:feedbacks)
+  end
+
+  let(:data) do
+    LHS::Data.new(json, nil, Record)
+  end
+
+  let(:item) do
+    data[0]
+  end
+
+  it 'does not respond to to_ary' do
+    expect(item.respond_to?(:to_ary)).to eq false
+  end
+end


### PR DESCRIPTION
Some functions in Rails find out if an object is an Array (or Array-like) by checking if it responds to the method `to_ary`. Since LHS usually responds to _everything_, it returned true for that, but then returned `nil` for `to_ary`. This gave problems especially with `fields_for`.