### PR TITLE
Fix accessing options

### DIFF
--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -7,6 +7,7 @@ class LHS::Record
 
     # You can start new option chains for already fetched records (needed for save, update, valid etc.)
     def options(hash = nil)
+      return method_missing(:options) if hash.nil?
       Chain.new(self.class, Option.new(hash), self)
     end
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.3.2'
+  VERSION = '15.3.3.pre.fixoptions.1'
 end

--- a/spec/record/options_getter_spec.rb
+++ b/spec/record/options_getter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  
+  context 'options' do
+    before do
+      class Record < LHS::Record
+        endpoint 'http://local.ch/records'
+      end
+    end
+
+    let(:raw) do
+      { options: { criticality: :high } }
+    end
+
+    def record
+      LHS::Record.new LHS::Data.new(raw, nil, Record)
+    end
+
+    it 'is possible to fetch data from a key called options from an instance' do
+      expect(record.options.criticality).to eq :high
+    end
+  end
+end


### PR DESCRIPTION
_PATCH_

# Before

It was not possible to access options, if a record underlying data had an attribute named `options`.

# Now

You can access `record.options`. e.g. needed for the new pricing service.  `price.options`