### PR TITLE
to_ary for LHS::Record

### DIFF
--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -58,7 +58,7 @@ class LHS::Record
   include RequestCycleCache
   include Scope
 
-  delegate :_proxy, :_endpoint, :merge_raw!, :select, :becomes, to: :_data
+  delegate :_proxy, :_endpoint, :merge_raw!, :select, :becomes, :respond_to?, to: :_data
 
   def initialize(data = nil, apply_customer_setters = true)
     data ||= LHS::Data.new({}, nil, self.class)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.4.0'
+  VERSION = '15.4.1'
 end

--- a/spec/record/to_ary_spec.rb
+++ b/spec/record/to_ary_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  let(:user_item) do
+    {
+      email: 'someone@somewhe.re'
+    }
+  end
+
+  let(:item) do
+    {
+      href: 'http://datastore/records/1',
+      user: user_item
+    }
+  end
+
+  let(:record) { Record.find(1) }
+
+  before do
+    class User < LHS::Record
+    end
+
+    class Record < LHS::Record
+      endpoint 'http://datastore/records/{id}'
+
+      has_one :user, class_name: 'User'
+    end
+
+    stub_request(:get, 'http://datastore/records/1')
+      .to_return(body: item.to_json)
+  end
+
+  describe 'respond_to?(:to_ary)' do
+    context 'when creating item' do
+      let(:record) do
+        Record.new(user: User.new)
+      end
+
+      it 'does not respond to to_ary' do
+        expect(record.user.respond_to?(:to_ary)).to eq false
+      end
+    end
+
+    context 'when returning a single item' do
+      it 'does not respond to to_ary' do
+        expect(record.user.respond_to?(:to_ary)).to eq false
+      end
+    end
+
+    context 'when returning array of items' do
+      let(:user_item) do
+        [
+          { email: 'someone@somewhe.re' },
+          { email: 'someone.else@somewhe.re' }
+        ]
+      end
+
+      it 'responds to to_ary' do
+        expect(record.user.respond_to?(:to_ary)).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Quick fix to get `respond_to?(to_ary)` to work correctly for classes derived from `LHS::Record`.