### PR TITLE
Ambiguous not clashing

### DIFF
--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -44,13 +44,13 @@ class LHS::Record
         endpoint
       end
 
-      # Prevent clashing endpoints.
+      # Prevent ambiguous endpoints
       def sanity_check(new_endpoint)
         endpoints.each do |existing_endpoint|
           invalid = existing_endpoint.placeholders.sort == new_endpoint.placeholders.sort &&
             existing_endpoint.url != new_endpoint.url
           next unless invalid
-          raise "Clashing endpoints! Cannot differentiate between #{existing_endpoint.url} and #{new_endpoint.url}"
+          raise "Ambiguous endpoints! Cannot differentiate between #{existing_endpoint.url} and #{new_endpoint.url}"
         end
       end
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.5.0'
+  VERSION = '15.5.1'
 end

--- a/spec/record/endpoint_inheritance_spec.rb
+++ b/spec/record/endpoint_inheritance_spec.rb
@@ -39,7 +39,7 @@ describe LHS::Record do
     end
   end
 
-  context 'clashing endpoints between super and subclass' do
+  context 'ambiguous endpoints between super and subclass' do
     before do
       class Base < LHS::Record
         endpoint 'records'

--- a/spec/record/endpoint_misconfiguration_spec.rb
+++ b/spec/record/endpoint_misconfiguration_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe LHS::Record do
   context 'misconfiguration of endpoints' do
-    it 'fails trying to add clashing endpoints' do
+    it 'fails trying to add ambiguous endpoints' do
       expect(
         lambda {
           class Record < LHS::Record
@@ -10,7 +10,7 @@ describe LHS::Record do
             endpoint '{+datastore}/v2/reviews'
           end
         }
-      ).to raise_error(/Clashing endpoints/)
+      ).to raise_error(/Ambiguous endpoints/)
 
       expect(
         lambda {
@@ -19,7 +19,7 @@ describe LHS::Record do
             endpoint '{+datastore}/v2/{campaign_id}/reviews'
           end
         }
-      ).to raise_error(/Clashing endpoints/)
+      ).to raise_error(/Ambiguous endpoints/)
     end
   end
 end


### PR DESCRIPTION
_MINOR_

The previous wording of "clashing" endpoints was rather imprecise. 

This PR switches the wording  to "ambiguous", which seems to be more precise and more common in software engineering.