### PR TITLE
Improve retrieving collections from unpaginated endpoints

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,3 +44,6 @@ Naming/PredicateName:
 
 RSpec/MessageSpies:
   Enabled: false
+
+Style/RegexpLiteral:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-LHS
+mLHS
 ===
 
 LHS uses [LHC](//github.com/local-ch/LHC) for advanced http requests.
@@ -269,6 +269,20 @@ GET https://service.example.com/records/1
 
 ### Find multiple records
 
+#### fetch
+
+In case you want to just fetch the records endpoint, without applying any further queries, you can simply call `fetch`:
+
+```ruby
+# app/controllers/some_controller.rb
+
+records = Record.fetch
+
+```
+```
+  GET https://service.example.com/records
+```
+
 #### where
 
 You can query a service for records by using `where`:
@@ -322,6 +336,52 @@ records = Record.blue.available(true)
 ```
 ```
 GET https://service.example.com/records?color=blue&available=true
+```
+
+#### all
+
+You can fetch all remote records by using `all`. Pagination will be performed automatically (See: [Record pagination](#record-pagination))
+
+```ruby
+# app/controllers/some_controller.rb
+
+records = Record.all
+
+```
+```
+  GET https://service.example.com/records?limit=100
+  GET https://service.example.com/records?limit=100&offset=100
+  GET https://service.example.com/records?limit=100&offset=200
+```
+
+```ruby
+# app/controllers/some_controller.rb
+
+records.size # 300
+
+```
+
+#### all with unpaginated endpoints
+
+In case your record endpoints are not implementing any pagination, configure it to be `paginated: false`. Pagination will not be performed automatically in those cases:
+
+```ruby
+# app/models/record.rb
+
+class Record < LHS::Record
+  configuration paginated: false
+end
+
+```
+
+```ruby
+# app/controllers/some_controller.rb
+
+records = Record.all
+
+```
+```
+  GET https://service.example.com/records
 ```
 
 #### Retrieve the amount of a collection of items: count vs. length

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ GET https://service.example.com/records/1
 
 #### fetch
 
-In case you want to just fetch the records endpoint, without applying any further queries, you can simply call `fetch`:
+In case you want to just fetch the records endpoint, without applying any further queries or want to handle pagination, you can simply call `fetch`:
 
 ```ruby
 # app/controllers/some_controller.rb

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-mLHS
+LHS
 ===
 
 LHS uses [LHC](//github.com/local-ch/LHC) for advanced http requests.

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -16,6 +16,10 @@ class LHS::Record
         Chain.new(self, Parameter.new(hash))
       end
 
+      def fetch
+        Chain.new(self, nil).fetch
+      end
+
       def all(hash = nil)
         chain = Chain.new(self, Parameter.new(hash))
         chain._links.push(Option.new(all: true))

--- a/lib/lhs/concerns/record/configuration.rb
+++ b/lib/lhs/concerns/record/configuration.rb
@@ -63,6 +63,7 @@ class LHS::Record
       # Allows record to be configured as not paginated,
       # as by default it's considered paginated
       def paginated
+        return true if @configuration.blank?
         @configuration.fetch(:paginated, true)
       end
 

--- a/lib/lhs/concerns/record/configuration.rb
+++ b/lib/lhs/concerns/record/configuration.rb
@@ -60,6 +60,12 @@ class LHS::Record
         )
       end
 
+      # Allows record to be configured as not paginated,
+      # as by default it's considered paginated
+      def paginated
+        @configuration.fetch(:paginated, true)
+      end
+
       private
 
       def symbolize_unless_complex(value)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.5.1'
+  VERSION = '15.6.0'
 end

--- a/spec/record/fetch_spec.rb
+++ b/spec/record/fetch_spec.rb
@@ -8,17 +8,32 @@ describe LHS::Record do
   end
 
   context 'fetch' do
-    let!(:request_stub) do
-      stub_request(:get, "http://datastore/records/?available=true&color=blue&range=%3E26")
-        .to_return(body: [{
-          name: 'Steve'
-        }].to_json)
+
+    context 'to resolve the chain' do
+      let!(:request_stub) do
+        stub_request(:get, "http://datastore/records/?available=true&color=blue&range=%3E26")
+          .to_return(body: [{
+            name: 'Steve'
+          }].to_json)
+      end
+
+      it 'resolves chains' do
+        records = Record.where(color: 'blue').where(range: '>26', available: true).fetch
+        expect(request_stub).to have_been_requested
+        expect(records.first.name).to eq 'Steve'
+      end
     end
 
-    it 'resolves chains' do
-      records = Record.where(color: 'blue').where(range: '>26', available: true).fetch
-      expect(request_stub).to have_been_requested
-      expect(records.first.name).to eq 'Steve'
+    context 'to fetch the first response' do
+      let!(:request_stub) do
+        stub_request(:get, "http://datastore/records/")
+          .to_return(body: [{ name: 'Steve' }])
+      end
+
+      it 'does fetch the first response if requested directly on the record' do
+        records = Record.fetch
+        expect(records.first.name).to eq 'Steve'
+      end
     end
   end
 end


### PR DESCRIPTION
## Warn when requesting all from unpaginated endpoints

Fixes: https://github.com/local-ch/lhs/issues/311

When requesting `all` for not paginated endpoints, it's trying to load all pages. If the endpoint is not paginated, LHS loads for ever, as it doesn't know when to stop. Now it shows a warning if it does so, as the behaviour is still desired, for endpoints, that do implement pagination, but do not provide pagination meta data as part of the response.

```ruby
Record.all
# [Warning] "all" has been requested, but endpoint does not provide pagination meta data. If you just want to fetch the first response, use "where" or "fetch".
```

## all with unpaginated endpoints

Fixes: https://github.com/local-ch/lhs/issues/312

In case your record endpoints are not implementing any pagination, configure it to be `paginated: false`. Pagination will not be performed automatically in those cases:

```ruby
# app/models/record.rb

class Record < LHS::Record
  configuration paginated: false
end

```

```ruby
# app/controllers/some_controller.rb

records = Record.all

```
```
  GET https://service.example.com/records
```

## fetch

In case you want to just fetch the records endpoint, without applying any further queries or want to handle pagination, you can simply call `fetch`:

```ruby
# app/controllers/some_controller.rb

records = Record.fetch

```
```
  GET https://service.example.com/records
```