### PR TITLE
Apply custom setters for update

### DIFF
--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -25,7 +25,7 @@ class LHS::Item < LHS::Proxy
 
     def update!(params, options = {}, partial_update = false)
       options ||= {}
-      partial_record = record.new(LHS::Data.new(params, _data.parent, record))
+      partial_record = _record.new(LHS::Data.new(params, _data.parent, _record))
       _data.merge_raw!(partial_record._data)
       data_sent = partial_update ? partial_record._data : _data
       url = href || record.find_endpoint(id: id).compile(id: id)

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -25,9 +25,9 @@ class LHS::Item < LHS::Proxy
 
     def update!(params, options = {}, partial_update = false)
       options ||= {}
-      partial_data = record.new(LHS::Data.new(params, _data.parent, record))
-      _data.merge_raw!(partial_data)
-      data_sent = partial_update ? partial_data : _data
+      partial_record = record.new(LHS::Data.new(params, _data.parent, record))
+      _data.merge_raw!(partial_record._data)
+      data_sent = partial_update ? partial_record._data : _data
       url = href || record.find_endpoint(id: id).compile(id: id)
       response_data = record.request(
         options.merge(

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -25,7 +25,7 @@ class LHS::Item < LHS::Proxy
 
     def update!(params, options = {}, partial_update = false)
       options ||= {}
-      partial_data = LHS::Data.new(params, _data.parent, record)
+      partial_data = record.new(LHS::Data.new(params, _data.parent, record))
       _data.merge_raw!(partial_data)
       data_sent = partial_update ? partial_data : _data
       url = href || record.find_endpoint(id: id).compile(id: id)

--- a/lib/lhs/concerns/record/custom_setters.rb
+++ b/lib/lhs/concerns/record/custom_setters.rb
@@ -1,0 +1,20 @@
+require 'active_support'
+
+class LHS::Record
+
+  module CustomSetters
+    extend ActiveSupport::Concern
+
+    private
+
+    def apply_custom_setters!
+      return if !_data.item? || !_data._raw.respond_to?(:keys)
+      raw = _data._raw
+      custom_setters = raw.keys.find_all { |key| public_methods.include?("#{key}=".to_sym) }
+      custom_setters.each do |setter|
+        value = raw.delete(setter)
+        send("#{setter}=", value)
+      end
+    end
+  end
+end

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -7,6 +7,8 @@ class LHS::Record
     'lhs/concerns/record/configuration'
   autoload :Create,
     'lhs/concerns/record/create'
+  autoload :CustomSetters,
+    'lhs/concerns/record/custom_setters'
   autoload :Destroy,
     'lhs/concerns/record/destroy'
   autoload :Endpoints,
@@ -45,6 +47,7 @@ class LHS::Record
   include Chainable
   include Configuration
   include Create
+  include CustomSetters
   include Destroy
   include Endpoints
   include Equality
@@ -86,17 +89,5 @@ class LHS::Record
 
   def respond_to_missing?(name, include_all = false)
     _data.respond_to_missing?(name, include_all)
-  end
-
-  private
-
-  def apply_custom_setters!
-    return if !_data.item? || !_data._raw.respond_to?(:keys)
-    raw = _data._raw
-    custom_setters = raw.keys.find_all { |key| public_methods.include?("#{key}=".to_sym) }
-    custom_setters.each do |setter|
-      value = raw.delete(setter)
-      send("#{setter}=", value)
-    end
   end
 end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -86,7 +86,7 @@ describe LHS::Item do
 
           class AppointmentProposal < LHS::Record
             def appointments_attributes=(attributes)
-              self.appointments = attributes.map { |attribute| {'date_time': attribute[:date]} }
+              self.appointments = attributes.map { |attribute| { 'date_time': attribute[:date] } }
             end
           end
         end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -72,9 +72,38 @@ describe LHS::Item do
             id: 'abc',
             appointments: [1, 2, 3]
           }.to_json)
-          .to_return(status: 200, body: "", headers: {})
+          .to_return(status: 200)
         item.update(appointments: [{ id: 1 }, { id: 2 }, { id: 3 }])
         expect(item.appointments.to_a).to eq([1, 2, 3])
+      end
+
+      context 'with nested items' do
+        before do
+          class Booking < LHS::Record
+            endpoint 'http://bookings/bookings'
+            has_one :appointment_proposal
+          end
+
+          class AppointmentProposal < LHS::Record
+            def appointments_attributes=(attributes)
+              self.appointments = attributes.map { |attribute| {'date_time': attribute[:date]} }
+            end
+          end
+        end
+
+        let(:item) do
+          Booking.new(id: 'abc', appointment_proposal: { appointments: [] })
+        end
+
+        it 'updates data using custom setters before send to backend' do
+          stub_request(:post, "http://bookings/bookings")
+            .with(body: {
+              appointments: [{ date_time: '2018-01-18' }]
+            }.to_json)
+            .to_return(status: 200)
+          item.appointment_proposal.update(appointments_attributes: [{ date: '2018-01-18' }])
+          expect(item.appointment_proposal.appointments.as_json).to eq([{ 'date_time' => '2018-01-18' }])
+        end
       end
     end
   end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -48,6 +48,35 @@ describe LHS::Item do
       expect(item.name).to eq 'Andrea'
       expect(item.likes).not_to eq 'Banana'
     end
+
+    context 'with custom setters' do
+      before do
+        class Booking < LHS::Record
+          endpoint 'http://bookings/bookings'
+
+          def appointments=(appointments)
+            super(
+              appointments.map { |appointment| appointment[:id] }
+            )
+          end
+        end
+      end
+
+      let(:item) do
+        Booking.new(id: 'abc')
+      end
+
+      it 'updates data using custom setters before send to backend' do
+        stub_request(:post, "http://bookings/bookings")
+          .with(body: {
+            id: 'abc',
+            appointments: [1, 2, 3]
+          }.to_json)
+          .to_return(status: 200, body: "", headers: {})
+        item.update(appointments: [{ id: 1 }, { id: 2 }, { id: 3 }])
+        expect(item.appointments.to_a).to eq([1, 2, 3])
+      end
+    end
   end
 
   context 'update!' do


### PR DESCRIPTION
This PR enables LHS to apply custom setters on `update` commands. Previously they only have been applied to `new` and `create`.

