### PR TITLE
Bump version dependency to LHC 10

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel'
   s.add_dependency 'activesupport', '> 4.2'
-  s.add_dependency 'lhc', '~> 9.2'
+  s.add_dependency 'lhc', '~> 10.0'
 
   s.add_development_dependency 'capybara'
   s.add_development_dependency 'json', '>=  1.8.2'

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '15.7.0'
+  VERSION = '16.0.0'
 end


### PR DESCRIPTION
Projects using LHS can't update to LHC just yet. This version allows them to.