### PR TITLE
Allow Batch Processing Request Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2077,7 +2077,7 @@ In case an API does not provide pagination information in the repsponse data (li
 `find_each` is a more fine grained way to process single records that are fetched in batches.
 
 ```ruby
-Record.find_each(start: 50, batch_size: 20, params: { has_reviews: true }) do |record|
+Record.find_each(start: 50, batch_size: 20, params: { has_reviews: true }, headers: { 'Authorization': 'Bearer 123' }) do |record|
   # Iterates over each record. Starts with record no. 50 and fetches 20 records each batch.
   record
   break if record.some_attribute == some_value
@@ -2089,7 +2089,7 @@ end
 `find_in_batches` is used by `find_each` and processes batches.
 
 ```ruby
-Record.find_in_batches(start: 50, batch_size: 20, params: { has_reviews: true }) do |records|
+Record.find_in_batches(start: 50, batch_size: 20, params: { has_reviews: true }, headers: { 'Authorization': 'Bearer 123' }) do |records|
   # Iterates over multiple records (batch size is 20). Starts with record no. 50 and fetches 20 records each batch.
   records
   break if records.first.name == some_value

--- a/lib/lhs/concerns/record/batch.rb
+++ b/lib/lhs/concerns/record/batch.rb
@@ -19,11 +19,13 @@ class LHS::Record
       # Process batches of entries
       def find_in_batches(options = {})
         raise 'No block given' unless block_given?
-        start = options[:start] || 1
-        batch_size = options[:batch_size] || LHS::Pagination::Base::DEFAULT_LIMIT
-        params = options[:params] || {}
+        options = options.dup
+        start = options.delete(:start) || 1
+        batch_size = options.delete(:batch_size) || LHS::Pagination::Base::DEFAULT_LIMIT
         loop do # as suggested by Matz
-          data = request(params: params.merge(limit_key(:parameter) => batch_size, pagination_key(:parameter) => start))
+          options = options.dup
+          options[:params] = (options[:params] || {}).merge(limit_key(:parameter) => batch_size, pagination_key(:parameter) => start)
+          data = request(options)
           batch_size = data._raw.dig(*limit_key(:body))
           left = data._raw.dig(*total_key).to_i - data._raw.dig(*pagination_key(:body)).to_i - data._raw.dig(*limit_key(:body)).to_i
           yield new(data)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '16.0.1'
+  VERSION = '16.1.0'
 end

--- a/spec/record/find_each_spec.rb
+++ b/spec/record/find_each_spec.rb
@@ -41,5 +41,15 @@ describe LHS::Collection do
       end
       expect(count).to eq total
     end
+
+    it 'passes options to the requests made' do
+      request = stub_request(:get, "http://local.ch/v2/feedbacks?limit=100&offset=1")
+        .with(headers: {'Authorization' => 'Bearer 123'})
+        .to_return(body: {
+          items: []
+        }.to_json)
+      Record.find_each(headers: { 'Authorization' => 'Bearer 123' }) {|record| }
+      expect(request).to have_been_made
+    end
   end
 end

--- a/spec/record/find_each_spec.rb
+++ b/spec/record/find_each_spec.rb
@@ -44,11 +44,11 @@ describe LHS::Collection do
 
     it 'passes options to the requests made' do
       request = stub_request(:get, "http://local.ch/v2/feedbacks?limit=100&offset=1")
-        .with(headers: {'Authorization' => 'Bearer 123'})
+        .with(headers: { 'Authorization' => 'Bearer 123' })
         .to_return(body: {
           items: []
         }.to_json)
-      Record.find_each(headers: { 'Authorization' => 'Bearer 123' }) {|record| }
+      Record.find_each(headers: { 'Authorization' => 'Bearer 123' }) { |record| }
       expect(request).to have_been_made
     end
   end


### PR DESCRIPTION
_MINOR_

This PR enables us to add more options than just params to the batch processing methods `find_each` and `find_in_batches`.