### PR TITLE
Cache the relations.

### DIFF
--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '16.1.0'
+  VERSION = '16.2.0'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '16.2.0'
+  VERSION = '16.1.1'
 end

--- a/spec/record/has_one_spec.rb
+++ b/spec/record/has_one_spec.rb
@@ -6,12 +6,14 @@ describe LHS::Record do
   let(:user) { transaction.user }
 
   before do
-    stub_request(:get, 'http://myservice/transactions/1')
-      .to_return(body: {
-        user: {
-          email_address: 'steve@local.ch'
-        }
-      }.to_json)
+    [1, 2].each do |id|
+      stub_request(:get, "http://myservice/transactions/#{id}")
+        .to_return(body: {
+          user: {
+            email_address: 'steve@local.ch'
+          }
+        }.to_json)
+    end
   end
 
   context 'has_one' do
@@ -39,6 +41,13 @@ describe LHS::Record do
     it 'keeps hirachy when casting it to another class on access' do
       expect(user._root._raw).to eq transaction._raw
       expect(user.parent._raw).to eq transaction._raw
+    end
+
+    it 'the relation is cached in memory' do
+      object_id = transaction.user.object_id
+      expect(transaction.user.object_id).to eql(object_id)
+      transaction2 = Transaction.find(2)
+      expect(transaction2.user.object_id).not_to eql(object_id)
     end
   end
 


### PR DESCRIPTION
The try to implement cache for relations.
Cache was not implemented directly in `LHS::Data::Becomes#becomes` because memoization will not work because we create a new instance of `LHS::Data` class every time we wrap a returned value (https://github.com/local-ch/lhs/compare/relation-cache?expand=1#diff-980515af88e289a4db6f934b06c27524R76).