### PR TITLE
Clear cache when call setter method. If it's possible use relations hash to get the class and cache the instance in the first place.

### DIFF
--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '16.1.1'
+  VERSION = '16.1.2'
 end


### PR DESCRIPTION
1. Clear cache to prevent the issues when the association(s) should be modified or at least not limit users:
```ruby
if user.comments.blank?
  user.comments = [Comment.new]
end
```
this code might be used in the form builder to build associations.

2. If it's possible user relations hash to get the class for the instance. If don't do it, then when `href` param is given for the record the branching with cache will not be reachable and in order to cover with cache another case we need to use more complex key, maybe something like `[klass, value]` but i think that currently it's not necessary since we can achieve associations cache without it.