### PR TITLE
Fix ignoring errors with find (with parameters)

### DIFF
--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -43,7 +43,7 @@ class LHS::Record
       end
 
       def get_unique_item!(data)
-        return unless data.present?
+        return if data.blank?
         if data._proxy.is_a?(LHS::Collection)
           raise LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
           data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -43,6 +43,7 @@ class LHS::Record
       end
 
       def get_unique_item!(data)
+        return unless data.present?
         if data._proxy.is_a?(LHS::Collection)
           raise LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
           data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -43,7 +43,7 @@ class LHS::Record
       end
 
       def get_unique_item!(data)
-        return if data.blank?
+        return if data.nil?
         if data._proxy.is_a?(LHS::Collection)
           raise LHC::NotFound.new('Requested unique item. Multiple were found.', data._request.response) if data.length > 1
           data.first || raise(LHC::NotFound.new('No item was found.', data._request.response))

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,3 +1,3 @@
 module LHS
-  VERSION = '16.1.2'
+  VERSION = '16.1.3'
 end

--- a/spec/record/ignore_errors_spec.rb
+++ b/spec/record/ignore_errors_spec.rb
@@ -91,6 +91,14 @@ describe LHS::Record do
       expect(record).to eq nil
     end
 
+    it 'returns nil also when ignoring errors on find with parameters' do
+      stub_request(:get, "http://local.ch/v2/records/1").to_return(status: 500, body: body)
+      record = Record
+        .ignore(LHC::Error)
+        .find(id: 1)
+      expect(record).to eq nil
+    end
+
     it 'returns nil also when ignoring errors on fetch' do
       stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 500, body: body)
       record = Record


### PR DESCRIPTION
_PATCH_

This PR fixes ignoring errors with find with parameters.

## BEFORE

```ruby
Record.ignore(LHC::NotFound).find(id: 2)
# was throwing exception
```

## Now 

Does not through exception but returns `nil` as expected.