### PR TITLE
Fix applying nested records endpoint options

### DIFF
--- a/Gemfile.activesupport4
+++ b/Gemfile.activesupport4
@@ -1,5 +1,4 @@
 source 'https://rubygems.org/'
 
 gemspec
-gem 'rails', '< 5.0.0'
 gem 'activesupport', '~> 4.2.0'

--- a/Gemfile.activesupport4
+++ b/Gemfile.activesupport4
@@ -1,4 +1,5 @@
 source 'https://rubygems.org/'
 
 gemspec
+gem 'rails', '< 5.0.0'
 gem 'activesupport', '~> 4.2.0'

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -76,7 +76,8 @@ class LHS::Proxy
     def wrap_return(value, record, name, args = nil)
       name = args.first if name == :[]
       return value unless worth_wrapping?(value)
-      data = (value.is_a?(LHS::Data) || value.is_a?(LHS::Record)) ? value : LHS::Data.new(value, _data, _record, _request)
+      # data = (value.is_a?(LHS::Data) || value.is_a?(LHS::Record)) ? value : LHS::Data.new(value, _data, _record, _request)
+      data = (value.is_a?(LHS::Data) || value.is_a?(LHS::Record)) ? value : LHS::Data.new(value, _data, record, _request)
       data.errors = LHS::Problems::Nested::Errors.new(errors, name) if errors.any?
       data.warnings = LHS::Problems::Nested::Warnings.new(warnings, name) if warnings.any?
       if _record && _record._relations[name]

--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -76,7 +76,6 @@ class LHS::Proxy
     def wrap_return(value, record, name, args = nil)
       name = args.first if name == :[]
       return value unless worth_wrapping?(value)
-      # data = (value.is_a?(LHS::Data) || value.is_a?(LHS::Record)) ? value : LHS::Data.new(value, _data, _record, _request)
       data = (value.is_a?(LHS::Data) || value.is_a?(LHS::Record)) ? value : LHS::Data.new(value, _data, record, _request)
       data.errors = LHS::Problems::Nested::Errors.new(errors, name) if errors.any?
       data.warnings = LHS::Problems::Nested::Warnings.new(warnings, name) if warnings.any?

--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -13,11 +13,14 @@ class LHS::Record
 
     mattr_accessor :all
 
+    included do
+      class_attribute :endpoints unless defined? endpoints
+      self.endpoints = []
+    end
+
     module ClassMethods
       # Adds the endpoint to the list of endpoints.
       def endpoint(url, options = nil)
-        class_attribute :endpoints unless defined? endpoints
-        self.endpoints ||= []
         self.endpoints = endpoints.clone
         validates_deprecation_check!(options)
         endpoint = LHC::Endpoint.new(url, options)
@@ -104,6 +107,7 @@ class LHS::Record
       # A base endpoint is the one thats has the least amont of placeholers.
       # There cannot be multiple base endpoints.
       def find_base_endpoint
+        return unless self.endpoints.present?
         endpoints = self.endpoints.group_by do |endpoint|
           endpoint.placeholders.length
         end

--- a/lib/lhs/concerns/record/endpoints.rb
+++ b/lib/lhs/concerns/record/endpoints.rb
@@ -107,7 +107,6 @@ class LHS::Record
       # A base endpoint is the one thats has the least amont of placeholers.
       # There cannot be multiple base endpoints.
       def find_base_endpoint
-        return unless self.endpoints.present?
         endpoints = self.endpoints.group_by do |endpoint|
           endpoint.placeholders.length
         end

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -27,7 +27,7 @@ class LHS::Data
     self._raw = raw_from_input(input)
     self._parent = parent
     self._record = record
-    self._proxy = proxy_from_input(input, record)
+    self._proxy = proxy_from_input(input)
     self._request = request
     self._endpoint = endpoint
   end
@@ -120,7 +120,7 @@ class LHS::Data
     _root == self
   end
 
-  def proxy_from_input(input, record)
+  def proxy_from_input(input)
     if input.is_a? LHS::Proxy
       input
     elsif collection_proxy?(raw_from_input(input))

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -27,7 +27,7 @@ class LHS::Data
     self._raw = raw_from_input(input)
     self._parent = parent
     self._record = record
-    self._proxy = proxy_from_input(input)
+    self._proxy = proxy_from_input(input, record)
     self._request = request
     self._endpoint = endpoint
   end
@@ -63,7 +63,7 @@ class LHS::Data
   end
 
   def class
-    _root._record
+    _record || _root._record
   end
 
   # enforce internal data structure to have deep symbolized keys
@@ -120,7 +120,7 @@ class LHS::Data
     _root == self
   end
 
-  def proxy_from_input(input)
+  def proxy_from_input(input, record)
     if input.is_a? LHS::Proxy
       input
     elsif collection_proxy?(raw_from_input(input))

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '16.1.6'
+  VERSION = '17.0.0'
 end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -87,6 +87,7 @@ describe LHS::Item do
           end
 
           class AppointmentProposal < LHS::Record
+            endpoint 'http://bookings/bookings'
             def appointments_attributes=(attributes)
               self.appointments = attributes.map { |attribute| { 'date_time': attribute[:date] } }
             end

--- a/spec/record/cast_nested_data_spec.rb
+++ b/spec/record/cast_nested_data_spec.rb
@@ -4,47 +4,75 @@ require 'rails_helper'
 
 describe LHS::Record do
   context 'cast nested data' do
-    let(:datastore) { 'http://local.ch/v2' }
-
-    before do
-      LHC.config.placeholder('datastore', datastore)
-      class Customer < LHS::Record
-        endpoint '{+datastore}/customers'
-        endpoint '{+datastore}/customers/{id}'
-      end
-      class Contract < LHS::Record
-        endpoint '{+datastore}/contracts'
-        endpoint '{+datastore}/contracts/{id}'
-      end
-      class Address < LHS::Record
-        endpoint '{+datastore}/addresses'
-        endpoint '{+datastore}/addresses/{id}'
-      end
-    end
-
-    it 'casts nested data properly' do
-      stub_request(:get, "http://local.ch/v2/customers?limit=1")
+    let(:stub_customer_request) do
+      stub_request(:get, "https://datastore/customers?limit=1")
         .to_return(
           body: {
             items: [
               {
-                href: "http://local.ch/v2/customers/12",
+                href: "https://datastore/customers/12",
                 address: {
-                  href: "http://local.ch/v2/addresses/3"
+                  href: "https://datastore/addresses/3"
                 },
                 contracts: [
                   {
-                    href: "http://local.ch/v2/contracts/2"
+                    href: "https://datastore/contracts/2"
                   }
                 ]
               }
             ]
           }.to_json
         )
+    end
+
+    before do
+      class Customer < LHS::Record
+        endpoint 'https://datastore/customers'
+        endpoint 'https://datastore/customers/{id}'
+      end
+      class Contract < LHS::Record
+        endpoint 'https://datastore/contracts'
+        endpoint 'https://datastore/contracts/{id}'
+      end
+      class Address < LHS::Record
+        endpoint 'https://datastore/addresses'
+        endpoint 'https://datastore/addresses/{id}', headers: { 'Authorization' => 'Bearer 123' }
+      end
+      stub_customer_request
+    end
+
+    it 'casts nested data properly' do
       customer = Customer.first
       expect(customer).to be_kind_of Customer
       expect(customer.address).to be_kind_of Address
       expect(customer.contracts.first).to be_kind_of Contract
+    end
+
+    context 'interact with nested resouce remotely' do
+      let(:address_request_stub) do
+        stub_request(:post, "https://datastore/addresses/3")
+          .with(
+            body: {
+              href: 'https://datastore/addresses/3',
+              zip: 8050
+            }.to_json,
+            headers: {
+              'Authorization': 'Bearer 123'
+            }
+          )
+          .to_return(status: 201)
+      end
+
+      before do
+        address_request_stub
+      end
+
+      it 'applies casted records endpoint options to requests made to the nested resource' do
+        customer = Customer.first
+        address = customer.address
+        address.zip = 8050
+        address.save
+      end
     end
   end
 end


### PR DESCRIPTION
_MAJOR_

Applying nested record endpoint options was not working, because internally, always the options of the root record has been applied:

```ruby
class Account < LHS::Record
  endpoint "https://datastore/accounts"
end

class CustomerRelation < LHS::Record
  endpoint "https://datastore/accounts/{account_id}/customer-relations", auth: { bearer: '123' }
end
```

```ruby
new_account = Account.create(email: 'some@email.com')
```
```
POST https://datastore/accounts
{ customer_relations: { href: 'https://datastore/accounts/123/customer-relations' } }
```

```ruby
customer_relation = new_account.customer_relations
customer_relation.local_customer_id = '123'
customer_relation.save!
```
Was not applying the configured bearer token options on the records endpoint.

# Now

It does apply the records endpoint options as expected.

# Breaking Change
Major version increase, as according to the tests, it might break existing implementations (like booking) that relied on the root record endpoints being used. 

# Migration Path

Add explicit endpoint to the affected nested record. 
See: https://github.com/local-ch/lhs/pull/332/files#diff-45624f27ac5c98e99c577ba56bf33759R90

