### PR TITLE
Clear cache of associations when lhs includes new resources

### DIFF
--- a/lib/lhs/concerns/proxy/accessors.rb
+++ b/lib/lhs/concerns/proxy/accessors.rb
@@ -12,6 +12,10 @@ class LHS::Proxy
 
     delegate :dig, :fetch, to: :_raw, allow_nil: true
 
+    def clear_cache!
+      @cache = nil
+    end
+
     private
 
     def set(name, value)
@@ -116,10 +120,6 @@ class LHS::Proxy
 
     def cache
       @cache ||= Concurrent::Map.new
-    end
-
-    def clear_cache!
-      @cache = nil
     end
   end
 end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -166,6 +166,7 @@ class LHS::Record
         else
           handle_include(includes, data, nil, references[includes])
         end
+        data.clear_cache! # as we just included new nested resources
       end
 
       def handle_include(included, data, sub_includes = nil, reference = nil)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '18.0.1'
+  VERSION = '18.0.2'
 end

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -56,9 +56,6 @@ describe LHS::Record do
       class AvailableAsset < LHS::Record
       end
 
-      stub_request(:get, place_hash[:href])
-        .to_return(body: place_hash.to_json)
-
       stub_request(:get, "http://datastore/places/#{place_id}/available-assets?limit=100")
         .to_return(body: {
           total: available_assets.size,
@@ -83,10 +80,32 @@ describe LHS::Record do
     let(:available_assets) { [available_asset_hash] }
 
     it 'clears the cache when using find' do
+      stub_request(:get, place_hash[:href])
+        .to_return(body: place_hash.to_json)
       place = Place
         .options(auth: { bearer: 'XYZ' })
         .includes_all(:available_assets)
         .find(place_id)
+      expect(place.available_assets.first).to be_a(AvailableAsset)
+    end
+
+    it 'clears the cache when using where' do
+      stub_request(:get, place_hash[:href])
+        .to_return(body: place_hash.to_json)
+      place = Place
+        .options(auth: { bearer: 'XYZ' })
+        .includes_all(:available_assets)
+        .where(id: place_id)
+      expect(place.available_assets.first).to be_a(AvailableAsset)
+    end
+
+    it 'clears the cache when using find_by' do
+      stub_request(:get, "https://datastore/places/#{place_id}?limit=1")
+        .to_return(body: place_hash.to_json)
+      place = Place
+        .options(auth: { bearer: 'XYZ' })
+        .includes_all(:available_assets)
+        .find_by(id: place_id)
       expect(place.available_assets.first).to be_a(AvailableAsset)
     end
   end

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -45,73 +45,7 @@ describe LHS::Record do
     end
   end
 
-  # TODO move
-  context 'clearing cache when including associations' do
-    before do
-      class Place < LHS::Record
-        endpoint 'https://datastore/places/{id}', followlocation: true, headers: { 'Prefer' => 'redirect-strategy=redirect-over-not-found' }
-        has_many :available_assets
-      end
-
-      class AvailableAsset < LHS::Record
-      end
-
-      stub_request(:get, "http://datastore/places/#{place_id}/available-assets?limit=100")
-        .to_return(body: {
-          total: available_assets.size,
-          items: available_assets
-        }.to_json)
-    end
-
-    let(:place_id) { SecureRandom.urlsafe_base64 }
-
-    let(:place_hash) do
-      {
-        href: "https://datastore/places/#{place_id}",
-        id: place_id,
-        available_assets: { href: "http://datastore/places/#{place_id}/available-assets?offset=0&limit=10" }
-      }
-    end
-
-    let(:available_asset_hash) do
-      { asset_code: 'OPENING_HOURS' }
-    end
-
-    let(:available_assets) { [available_asset_hash] }
-
-    it 'clears the cache when using find' do
-      stub_request(:get, place_hash[:href])
-        .to_return(body: place_hash.to_json)
-      place = Place
-        .options(auth: { bearer: 'XYZ' })
-        .includes_all(:available_assets)
-        .find(place_id)
-      expect(place.available_assets.first).to be_a(AvailableAsset)
-    end
-
-    it 'clears the cache when using where' do
-      stub_request(:get, place_hash[:href])
-        .to_return(body: place_hash.to_json)
-      place = Place
-        .options(auth: { bearer: 'XYZ' })
-        .includes_all(:available_assets)
-        .where(id: place_id)
-      expect(place.available_assets.first).to be_a(AvailableAsset)
-    end
-
-    it 'clears the cache when using find_by' do
-      stub_request(:get, "https://datastore/places/#{place_id}?limit=1")
-        .to_return(body: place_hash.to_json)
-      place = Place
-        .options(auth: { bearer: 'XYZ' })
-        .includes_all(:available_assets)
-        .find_by(id: place_id)
-      expect(place.available_assets.first).to be_a(AvailableAsset)
-    end
-  end
-
   context 'custom class_name' do
-
     before do
       module Uberall
         class Location < LHS::Record

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -85,8 +85,8 @@ describe LHS::Record do
     it 'has many available assets' do
       place = Place
         .options(auth: { bearer: 'XYZ' })
-        .includes_all(:available_assets).find(place_id)
-        binding.pry
+        .includes_all(:available_assets)
+        .find(place_id)
       expect(place.available_assets.first).to be_a(AvailableAsset)
     end
   end

--- a/spec/record/has_one_spec.rb
+++ b/spec/record/has_one_spec.rb
@@ -20,7 +20,6 @@ describe LHS::Record do
   end
 
   context 'has_one' do
-
     before do
       class Transaction < LHS::Record
         endpoint 'http://myservice/transactions'
@@ -48,23 +47,6 @@ describe LHS::Record do
     it 'keeps hirachy when casting it to another class on access' do
       expect(user._root._raw).to eq transaction._raw
       expect(user.parent._raw).to eq transaction._raw
-    end
-
-    it 'caches the relation in memory' do
-      allow(LHS::Record).to receive(:for_url).and_return(User)
-      user_object_id = transaction.user.object_id
-      expect(transaction.user.object_id).to eql(user_object_id)
-      transaction2 = Transaction.find(2)
-      expect(transaction2.user.object_id).not_to eql(user_object_id)
-    end
-
-    it 'recalculates cache for relation when it was modified' do
-      allow(LHS::Record).to receive(:for_url).and_return(Comment)
-      expect(user.comments).to be_blank
-      comments_object_id = user.comments.object_id
-      user.comments = [Comment.new]
-      expect(user.comments.object_id).not_to eql(comments_object_id)
-      expect(user.comments).not_to be_blank
     end
   end
 

--- a/spec/record/relation_caching_spec.rb
+++ b/spec/record/relation_caching_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe LHS::Record do

--- a/spec/record/relation_caching_spec.rb
+++ b/spec/record/relation_caching_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'cache' do
+    let(:transaction) { Transaction.find(1) }
+    let(:user) { transaction.user }
+
+    before do
+      class Transaction < LHS::Record
+        endpoint 'http://myservice/transactions'
+        endpoint 'http://myservice/transactions/{id}'
+        has_one :user
+      end
+
+      class User < LHS::Record
+        has_many :comments
+
+        def email
+          self[:email_address]
+        end
+      end
+
+      class Comment < LHS::Record
+      end
+
+      [1, 2].each do |id|
+        stub_request(:get, "http://myservice/transactions/#{id}")
+          .to_return(body: {
+            user: {
+              email_address: 'steve@local.ch',
+              comments: []
+            }
+          }.to_json)
+      end
+    end
+
+    it 'caches the relation in memory' do
+      allow(LHS::Record).to receive(:for_url).and_return(User)
+      user_object_id = transaction.user.object_id
+      expect(transaction.user.object_id).to eql(user_object_id)
+      transaction2 = Transaction.find(2)
+      expect(transaction2.user.object_id).not_to eql(user_object_id)
+    end
+
+    it 'recalculates cache for relation when it was modified' do
+      allow(LHS::Record).to receive(:for_url).and_return(Comment)
+      expect(user.comments).to be_blank
+      comments_object_id = user.comments.object_id
+      user.comments = [Comment.new]
+      expect(user.comments.object_id).not_to eql(comments_object_id)
+      expect(user.comments).not_to be_blank
+    end
+  end
+
+  context 'clear cache' do
+    before do
+      class Place < LHS::Record
+        endpoint 'https://datastore/places/{id}', followlocation: true, headers: { 'Prefer' => 'redirect-strategy=redirect-over-not-found' }
+        has_many :available_assets
+      end
+
+      class AvailableAsset < LHS::Record
+      end
+
+      stub_request(:get, "http://datastore/places/#{place_id}/available-assets?limit=100")
+        .to_return(body: {
+          total: available_assets.size,
+          items: available_assets
+        }.to_json)
+    end
+
+    let(:place_id) { SecureRandom.urlsafe_base64 }
+
+    let(:place_hash) do
+      {
+        href: "https://datastore/places/#{place_id}",
+        id: place_id,
+        available_assets: { href: "http://datastore/places/#{place_id}/available-assets?offset=0&limit=10" }
+      }
+    end
+
+    let(:available_asset_hash) do
+      { asset_code: 'OPENING_HOURS' }
+    end
+
+    let(:available_assets) { [available_asset_hash] }
+
+    it 'clears the cache when using find' do
+      stub_request(:get, place_hash[:href])
+        .to_return(body: place_hash.to_json)
+      place = Place
+        .options(auth: { bearer: 'XYZ' })
+        .includes_all(:available_assets)
+        .find(place_id)
+      expect(place.available_assets.first).to be_a(AvailableAsset)
+    end
+
+    it 'clears the cache when using where' do
+      stub_request(:get, place_hash[:href])
+        .to_return(body: place_hash.to_json)
+      place = Place
+        .options(auth: { bearer: 'XYZ' })
+        .includes_all(:available_assets)
+        .where(id: place_id)
+      expect(place.available_assets.first).to be_a(AvailableAsset)
+    end
+
+    it 'clears the cache when using find_by' do
+      stub_request(:get, "https://datastore/places/#{place_id}?limit=1")
+        .to_return(body: place_hash.to_json)
+      place = Place
+        .options(auth: { bearer: 'XYZ' })
+        .includes_all(:available_assets)
+        .find_by(id: place_id)
+      expect(place.available_assets.first).to be_a(AvailableAsset)
+    end
+  end
+
+end


### PR DESCRIPTION
LHS used to cache associated resources. This PR does clear this cache when new resources are included.
Before:
```ruby
class Place < LHS::Record
  endpoint 'https://datastore/places/{id}'
  has_many :available_assets
end

class AvailableAsset < LHS::Record
end
```
```ruby
place = Place
  .options(auth: { bearer: 'XYZ' })
  .includes_all(:available_assets)
  .find(place_id)

place.available_assets.first
> nil
```
Now:
```ruby
place.available_assets.first
=> AvailableAsset https://datastore/places/4MTVj3Q8viP8645aU0eHSQ
> available_assets
:asset_code => "OPENING_HOURS"
```