### PR TITLE
Fix ignore errors in create cases

### DIFF
--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -34,9 +34,11 @@ class LHS::Item < LHS::Proxy
     end
 
     def create_and_merge_data!(options)
-      direct_response_data = record.request(options)
-      _data.merge_raw!(direct_response_data.unwrap(:item_created_key))
-      response_headers = direct_response_data._request.response.headers
+      response_data = record.request(options)
+      if response_data.present?
+        _data.merge_raw!(response_data.unwrap(:item_created_key))
+        response_headers = response_data._request.response.headers
+      end
       if response_headers && response_headers['Location']
         location_data = record.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
         _data.merge_raw!(location_data.unwrap(:item_created_key))

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '18.0.2'
+  VERSION = '18.0.3'
 end

--- a/spec/record/ignore_errors_spec.rb
+++ b/spec/record/ignore_errors_spec.rb
@@ -24,6 +24,16 @@ describe LHS::Record do
     end
   end
 
+  context 'ignore errors during create' do
+
+    it 'allows to ignore errors during create' do
+      stub_request(:post, 'http://local.ch/v2/records')
+        .to_return(status: 409)
+      record = Record.ignore(LHC::Conflict).create(name: 'Steve')
+      expect(record._raw).to eq(name: 'Steve')
+    end
+  end
+
   context 'multiple ignored errors' do
     it 'ignores error if first of them is specified' do
       stub_request(:get, "http://local.ch/v2/records?color=blue").to_return(status: 401)


### PR DESCRIPTION
_PATCH_

LHS was raising exceptions when `ignore` was used in combination with `create`.

e.g. 
```ruby
Record.ignore(LHC::Conflict).create(name: 'Steve')
```

This PR fixes that case.