### PR TITLE
Association configuration

### DIFF
--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -106,12 +106,14 @@ describe LHS::Record do
 
       stub_request(:get, "https://categories/categories/1")
         .to_return(body: {
+          href: 'https://categories/categories/1',
           category_name: 'Pizza'
         }.to_json)
     end
 
     it 'explicit association configuration overrules href class casting' do
       place = Place.includes(:categories).find(1)
+      expect(place.categories.first).to be_kind_of NewCategory
       expect(place.categories.first.name).to eq('Pizza')
     end
   end

--- a/spec/record/has_many_spec.rb
+++ b/spec/record/has_many_spec.rb
@@ -77,4 +77,42 @@ describe LHS::Record do
       expect(listing.parent.parent._raw).to eq location._raw
     end
   end
+
+  context 'explicit association class configuration overrules href class casting' do
+    before do
+      class Place < LHS::Record
+        endpoint 'http://places/places/{id}'
+        has_many :categories, class_name: 'NewCategory'
+      end
+
+      class NewCategory < LHS::Record
+        endpoint 'http://newcategories/newcategories/{id}'
+
+        def name
+          self['category_name']
+        end
+      end
+
+      class Category < LHS::Record
+        endpoint 'http://categories/categories/{id}'
+      end
+
+      stub_request(:get, "http://places/places/1")
+        .to_return(body: {
+          categories: [{
+            href: 'https://categories/categories/1'
+          }]
+        }.to_json)
+
+      stub_request(:get, "https://categories/categories/1")
+        .to_return(body: {
+          category_name: 'Pizza'
+        }.to_json)
+    end
+
+    it 'explicit association configuration overrules href class casting' do
+      place = Place.includes(:categories).find(1)
+      expect(place.categories.first.name).to eq('Pizza')
+    end
+  end
 end

--- a/spec/record/has_one_spec.rb
+++ b/spec/record/has_one_spec.rb
@@ -102,12 +102,14 @@ describe LHS::Record do
 
       stub_request(:get, "https://categories/categories/1")
         .to_return(body: {
+          href: 'https://categories/categories/1',
           category_name: 'Pizza'
         }.to_json)
     end
 
     it 'explicit association configuration overrules href class casting' do
       place = Place.includes(:category).find(1)
+      expect(place.category).to be_kind_of NewCategory
       expect(place.category.name).to eq('Pizza')
     end
   end


### PR DESCRIPTION
This PR adds tests that proof that explicit association configuration comes before href, when determine/casting a class (record) in LHS.