### PR TITLE
Endpoint with multiple placeholders

### DIFF
--- a/lib/lhs/concerns/item/endpoint_lookup.rb
+++ b/lib/lhs/concerns/item/endpoint_lookup.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'active_support'
+
+class LHS::Item < LHS::Proxy
+  module EndpointLookup
+    extend ActiveSupport::Concern
+
+    def url_for_persistance!(data, options)
+      return href if href.present?
+      endpoint = endpoint_for_persistance!(data, options)
+      endpoint.compile(
+        merge_data_with_options(data, options)
+      ).tap do
+        endpoint.remove_interpolated_params!(data)
+        endpoint.remove_interpolated_params!(options.fetch(:params, {}))
+        options.merge!(endpoint.options.merge(options)) if endpoint.options
+      end
+    end
+
+    private
+
+    def endpoint_for_persistance!(data, options)
+      record.find_endpoint(merge_data_with_options(data, options))
+    end
+  end
+end

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -3,9 +3,15 @@
 require 'active_support'
 
 class LHS::Item < LHS::Proxy
+  autoload :EndpointLookup,
+    'lhs/concerns/item/endpoint_lookup'
 
   module Save
     extend ActiveSupport::Concern
+
+    included do
+      include EndpointLookup
+    end
 
     def save(options = nil)
       save!(options)
@@ -16,7 +22,7 @@ class LHS::Item < LHS::Proxy
     def save!(options = {})
       options = options.present? ? options.dup : {}
       data = _data._raw.dup
-      url = url_for_persistance!(options, data)
+      url = url_for_persistance!(data, options)
       create_and_merge_data!(
         apply_default_creation_options(options, url, data)
       )
@@ -44,22 +50,6 @@ class LHS::Item < LHS::Proxy
         _data.merge_raw!(location_data.unwrap(:item_created_key))
       end
       true
-    end
-
-    def endpoint_for_persistance(data, options)
-      record.find_endpoint(merge_data_with_options(data, options))
-    end
-
-    def url_for_persistance!(options, data)
-      return href if href.present?
-      endpoint = endpoint_for_persistance(data, options)
-      endpoint.compile(
-        merge_data_with_options(data, options)
-      ).tap do
-        endpoint.remove_interpolated_params!(data)
-        endpoint.remove_interpolated_params!(options.fetch(:params, {}))
-        options.merge!(endpoint.options.merge(options)) if endpoint.options
-      end
     end
   end
 end

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -30,7 +30,7 @@ class LHS::Item < LHS::Proxy
       partial_record = _record.new(LHS::Data.new(params, _data.parent, _record))
       _data.merge_raw!(partial_record._data)
       data_sent = partial_update ? partial_record._data : _data
-      url = href || record.find_endpoint(id: id).compile(id: id)
+      url = href || record.find_endpoint(_data.to_h).compile(_data.to_h)
       response_data = record.request(
         options.merge(
           method: options.fetch(:method, :post),

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -35,8 +35,8 @@ class LHS::Item < LHS::Proxy
       options = options.present? ? options.dup : {}
       partial_record = _record.new(LHS::Data.new(params, _data.parent, _record))
       _data.merge_raw!(partial_record._data)
-      data = _data._raw.dup
-      url = url_for_persistance!(data, options)
+      data = _data.dup
+      url = url_for_persistance!(data._raw, options)
       data_sent = partial_update ? partial_record._data : data
       response_data = record.request(
         options.merge(

--- a/lib/lhs/concerns/item/update.rb
+++ b/lib/lhs/concerns/item/update.rb
@@ -35,9 +35,10 @@ class LHS::Item < LHS::Proxy
       options = options.present? ? options.dup : {}
       partial_record = _record.new(LHS::Data.new(params, _data.parent, _record))
       _data.merge_raw!(partial_record._data)
-      data = _data.dup
-      url = url_for_persistance!(data._raw, options)
-      data_sent = partial_update ? partial_record._data : data
+      data = _data._raw.dup
+      partial_data = partial_record._data._raw.dup
+      url = url_for_persistance!(data, options)
+      data_sent = partial_update ? partial_data.extract!(*data.keys) : data
       response_data = record.request(
         options.merge(
           method: options.fetch(:method, :post),

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.0.0.pre.endpoint.1'
+  VERSION = '19.0.0'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '18.0.3'
+  VERSION = '19.0.0.pre.endpoint.1'
 end

--- a/spec/item/save_spec.rb
+++ b/spec/item/save_spec.rb
@@ -102,11 +102,11 @@ describe LHS::Item do
     it 'keeps header psassed in the options' do
       headers = { 'Stats' => 'first-access' }
       request = stub_request(:post, item.href)
-                  .with(
-                    body: item._raw.to_json,
-                    headers: headers
-                  )
-                  .to_return(status: 200, body: item._raw.to_json)
+        .with(
+          body: item._raw.to_json,
+          headers: headers
+        )
+        .to_return(status: 200, body: item._raw.to_json)
 
       item.save!(headers: headers)
       expect(request).to have_been_requested

--- a/spec/item/save_spec.rb
+++ b/spec/item/save_spec.rb
@@ -63,6 +63,34 @@ describe LHS::Item do
     end
   end
 
+  context 'with many placeholders' do
+    before do
+      class GrandChild < LHS::Record
+        endpoint 'http://host/v2/parents/{parent_id}/children/{child_id}/grand_children'
+        endpoint 'http://host/v2/parents/{parent_id}/children/{child_id}/grand_children/{id}'
+      end
+    end
+
+    let(:data) do
+      {
+        parent_id: "bbb",
+        child_id: 'ccc',
+        name: "Lorem"
+      }
+    end
+
+    let(:item) do
+      GrandChild.new(data)
+    end
+
+    it 'persists changes on the backend' do
+      stub_request(:post, 'http://host/v2/parents/bbb/children/ccc/grand_children')
+        .with(body: { name: "Lorem" }.to_json)
+
+      expect(item.save).to eq true
+    end
+  end
+
   context 'save!' do
     it 'raises if something goes wrong' do
       stub_request(:post, item.href)
@@ -74,11 +102,11 @@ describe LHS::Item do
     it 'keeps header psassed in the options' do
       headers = { 'Stats' => 'first-access' }
       request = stub_request(:post, item.href)
-        .with(
-          body: item._raw.to_json,
-          headers: headers
-        )
-        .to_return(status: 200, body: item._raw.to_json)
+                  .with(
+                    body: item._raw.to_json,
+                    headers: headers
+                  )
+                  .to_return(status: 200, body: item._raw.to_json)
 
       item.save!(headers: headers)
       expect(request).to have_been_requested

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -112,9 +112,9 @@ describe LHS::Item do
 
     context 'with many placeholders' do
       before do
-        class Record < LHS::Record
-          endpoint 'http://host/v2/parents/{parent_id}/records'
-          endpoint 'http://host/v2/parents/{parent_id}/records/{id}'
+        class Child < LHS::Record
+          endpoint 'http://host/v2/parents/{parent_id}/childs'
+          endpoint 'http://host/v2/parents/{parent_id}/childs/{id}'
         end
       end
 
@@ -122,18 +122,23 @@ describe LHS::Item do
         {
           id: "aaa",
           parent_id: "bbb",
-          content: "Lorem"
+          name: "Lorem"
         }
       end
 
       let(:item) do
-        Record.new(data)
+        Child.new(data)
       end
 
       it 'persists changes on the backend' do
-        # stub_request(:put, '{+datastore}/v2/{parent_id}/feedbacks/{id}')
-        #   .with(body: item._raw.merge(name: 'Steve').to_json)
-        result = item.update(content: 'Steve')
+        stub_request(:get, 'http://host/v2/parents/bbb/childs/aaa')
+          .to_return(status: 200, body: data.to_json)
+        stub_request(:put, 'http://host/v2/parents/bbb/childs/aaa')
+          .with(body: item._raw.merge(name: 'Steve').to_json)
+
+        child = Child.find(parent_id: 'bbb', id: 'aaa')
+        expect(child.name).to eq('Lorem')
+        result = child.update(name: 'Steve')
         expect(result).to eq true
       end
     end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -112,9 +112,9 @@ describe LHS::Item do
 
     context 'with many placeholders' do
       before do
-        class Child < LHS::Record
-          endpoint 'http://host/v2/parents/{parent_id}/childs'
-          endpoint 'http://host/v2/parents/{parent_id}/childs/{id}'
+        class GrandChild < LHS::Record
+          endpoint 'http://host/v2/parents/{parent_id}/children/{child_id}/grand_children'
+          endpoint 'http://host/v2/parents/{parent_id}/children/{child_id}/grand_children/{id}'
         end
       end
 
@@ -122,23 +122,24 @@ describe LHS::Item do
         {
           id: "aaa",
           parent_id: "bbb",
+          child_id: 'ccc',
           name: "Lorem"
         }
       end
 
       let(:item) do
-        Child.new(data)
+        GrandChild.new(data)
       end
 
       it 'persists changes on the backend' do
-        stub_request(:get, 'http://host/v2/parents/bbb/childs/aaa')
+        stub_request(:get, 'http://host/v2/parents/bbb/children/ccc/grand_children/aaa')
           .to_return(status: 200, body: data.to_json)
-        stub_request(:post, 'http://host/v2/parents/bbb/childs/aaa')
+        stub_request(:post, 'http://host/v2/parents/bbb/children/ccc/grand_children/aaa')
           .with(body: item._raw.merge(name: 'Steve').to_json)
 
-        child = Child.find(parent_id: 'bbb', id: 'aaa')
-        expect(child.name).to eq('Lorem')
-        result = child.update(name: 'Steve')
+        grand_child = GrandChild.find(parent_id: 'bbb', child_id: 'ccc', id: 'aaa')
+        expect(grand_child.name).to eq('Lorem')
+        result = grand_child.update(name: 'Steve')
         expect(result).to eq true
       end
     end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -88,6 +88,7 @@ describe LHS::Item do
 
           class AppointmentProposal < LHS::Record
             endpoint 'http://bookings/bookings'
+
             def appointments_attributes=(attributes)
               self.appointments = attributes.map { |attribute| { 'date_time': attribute[:date] } }
             end
@@ -135,7 +136,7 @@ describe LHS::Item do
         stub_request(:get, 'http://host/v2/parents/bbb/children/ccc/grand_children/aaa')
           .to_return(status: 200, body: data.to_json)
         stub_request(:post, 'http://host/v2/parents/bbb/children/ccc/grand_children/aaa')
-          .with(body: item._raw.merge(name: 'Steve').to_json)
+          .with(body: { name: 'Steve' }.to_json)
 
         grand_child = GrandChild.find(parent_id: 'bbb', child_id: 'ccc', id: 'aaa')
         expect(grand_child.name).to eq('Lorem')

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -109,6 +109,34 @@ describe LHS::Item do
         end
       end
     end
+
+    context 'with many placeholders' do
+      before do
+        class Record < LHS::Record
+          endpoint 'http://host/v2/parents/{parent_id}/records'
+          endpoint 'http://host/v2/parents/{parent_id}/records/{id}'
+        end
+      end
+
+      let(:data) do
+        {
+          id: "aaa",
+          parent_id: "bbb",
+          content: "Lorem"
+        }
+      end
+
+      let(:item) do
+        Record.new(data)
+      end
+
+      it 'persists changes on the backend' do
+        # stub_request(:put, '{+datastore}/v2/{parent_id}/feedbacks/{id}')
+        #   .with(body: item._raw.merge(name: 'Steve').to_json)
+        result = item.update(content: 'Steve')
+        expect(result).to eq true
+      end
+    end
   end
 
   context 'update!' do

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -133,7 +133,7 @@ describe LHS::Item do
       it 'persists changes on the backend' do
         stub_request(:get, 'http://host/v2/parents/bbb/childs/aaa')
           .to_return(status: 200, body: data.to_json)
-        stub_request(:put, 'http://host/v2/parents/bbb/childs/aaa')
+        stub_request(:post, 'http://host/v2/parents/bbb/childs/aaa')
           .with(body: item._raw.merge(name: 'Steve').to_json)
 
         child = Child.find(parent_id: 'bbb', id: 'aaa')

--- a/spec/record/options_spec.rb
+++ b/spec/record/options_spec.rb
@@ -119,7 +119,7 @@ describe LHS::Record do
       context 'update' do
         before do
           stub_request(:post, "http://datastore/v2/records/123").to_return(body: {}.to_json)
-          body = LHS::Data.new({ href: 'http://datastore/v2/records/123', name: 'steve' }, nil, Record)
+          body = { href: 'http://datastore/v2/records/123', name: 'steve' }
           expect(LHC).to receive(:request)
             .with(options.merge(method: :post, url: "http://datastore/v2/records/123", body: body))
             .and_call_original


### PR DESCRIPTION
_MAJOR_

## Changes
- Extract `url_for_persistance!` in a separate module used by `save`
- Use the new extracted method to lookup the endpoint for `update`
- Remove interpolated params from `data` and `options` when using `url_for_persistance!`
- This change also fixes update endpoint lookup using multiple placeholders 

