### PR TITLE
Fixes includes_all trough single item

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -147,7 +147,7 @@ class LHS::Record
       def extend_base_item_with_hash_of_items!(target, addition)
         LHS::Collection.nest(input: target._raw, value: [], record: self)
         if LHS::Collection.access(input: target._raw, record: self).empty?
-          LHS::Collection.nest(input: target._raw, value: addition.map(&:_raw), record: self)
+          LHS::Collection.nest(input: target._raw, value: addition.compact.map(&:_raw), record: self)
         else
           LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
             item.merge!(addition[index])
@@ -242,7 +242,7 @@ class LHS::Record
           load_and_merge_paginated_collection!(data, options)
         elsif data.collection? && paginated?(data.first.try(:_raw))
           load_and_merge_set_of_paginated_collections!(data, options)
-        elsif load_not_paginated_collection
+        elsif load_not_paginated_collection && data.collection?
           warn('[Warning] "all" has been requested, but endpoint does not provide pagination meta data. If you just want to fetch the first response, use "where" or "fetch".')
           load_and_merge_not_paginated_collection!(data, options)
         end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.0.0'
+  VERSION = '19.0.1'
 end

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -561,7 +561,7 @@ describe LHS::Record do
       place = Place
         .includes_all(customer: :addresses)
         .find(1)
-      expect(place.customer.addresses.map(&:no)).to eq [1,2]
+      expect(place.customer.addresses.map(&:no)).to eq [1, 2]
     end
   end
 end

--- a/spec/record/includes_all_spec.rb
+++ b/spec/record/includes_all_spec.rb
@@ -523,4 +523,45 @@ describe LHS::Record do
       end
     end
   end
+
+  context 'includes collection trough single item' do
+
+    before do
+      class Place < LHS::Record
+        endpoint 'https://places/{id}'
+      end
+
+      stub_request(:get, 'https://places/1')
+        .to_return(
+          body: {
+            customer: { href: 'https://customers/1' }
+          }.to_json
+        )
+
+      stub_request(:get, 'https://customers/1?limit=100')
+        .to_return(
+          body: {
+            addresses: { 'href': 'https://customer/1/addresses' }
+          }.to_json
+        )
+
+      stub_request(:get, 'https://customer/1/addresses?limit=100')
+        .to_return(
+          body: {
+            items: [
+              { city: 'Zurich', no: 1 },
+              { city: 'Zurich', no: 2 }
+            ],
+            total: 2
+          }.to_json
+        )
+    end
+
+    it 'includes a collection trough a single item without exceptions' do
+      place = Place
+        .includes_all(customer: :addresses)
+        .find(1)
+      expect(place.customer.addresses.map(&:no)).to eq [1,2]
+    end
+  end
 end


### PR DESCRIPTION
_PATCH_

LHS was raising:
```
Failure/Error: return if data.length.zero?
     
     NoMethodError:
       undefined method `zero?' for nil:NilClass
```

When you tried to include a collection (with `includes_all`) via a single item:

e.g.
```ruby
Place.includes_all(customer: addresses)
```

Now fixed.