### PR TITLE
Documentation about what create returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1358,7 +1358,9 @@ The kaminari’s page parameter is in params[:page]. For example, you can use ka
 
 ##### create
 
-`create` will return false if persisting fails. `create!` instead will raise an exception.
+`create` will return the object in memory if persisting fails, providing validation errors in `.errors` (See [record validation](#record-validation)).
+
+`create!` instead will raise an exception.
 
 `create` always builds the data of the local object first, before it tries to sync with an endpoint. So even if persisting fails, the local object is build.
 


### PR DESCRIPTION
Documentation was wrong about what `create` returns.

It's aligned with how ActiveRecord works in regards of `create`. too.

https://github.com/rails/rails/blob/5bc494b35e4c8b91f33b517928e32ee6a6d1ec20/railties/lib/rails/application.rb#L100