### PR TITLE
Override Object#dup.

### DIFF
--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -83,6 +83,12 @@ class LHS::Record
     new(data)
   end
 
+  # Override Object#dup because it doesn't support copying any singleton
+  # methods, which leads to missing `_data` method when you execute `dup`.
+  def dup
+    clone
+  end
+
   protected
 
   def method_missing(name, *args, &block)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.0.1'
+  VERSION = '19.0.2'
 end

--- a/spec/item/update_spec.rb
+++ b/spec/item/update_spec.rb
@@ -88,10 +88,14 @@ describe LHS::Item do
 
           class AppointmentProposal < LHS::Record
             endpoint 'http://bookings/bookings'
+            has_many :appointments
 
             def appointments_attributes=(attributes)
-              self.appointments = attributes.map { |attribute| { 'date_time': attribute[:date] } }
+              self.appointments = attributes.map { |attribute| Appointment.new('date_time': attribute[:date]) }
             end
+          end
+
+          class Appointment < LHS::Record
           end
         end
 

--- a/spec/record/dup_spec.rb
+++ b/spec/record/dup_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  describe '#dup' do
+    before do
+      class Appointment < LHS::Record
+      end
+    end
+
+    it 'returns a copy of an object' do
+      appointment = Appointment.new
+      copy = appointment.dup
+      expect(copy.inspect).to match(/Appointment/)
+      expect(copy).to be_kind_of(Appointment)
+      expect(copy.object_id).not_to eql(appointment.object_id)
+    end
+  end
+end


### PR DESCRIPTION
Override Object#dup because it doesn't support copying any singleton methods, which leads to missing `_data` method when you execute `dup`.