### PR TITLE
Remove attributes= for now

### DIFF
--- a/lib/lhs/concerns/record/attribute_assignment.rb
+++ b/lib/lhs/concerns/record/attribute_assignment.rb
@@ -13,7 +13,6 @@ class LHS::Record
 
       _assign_attributes(new_attributes)
     end
-    alias attributes= assign_attributes
 
     private
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.3.0'
+  VERSION = '19.3.1'
 end

--- a/spec/record/attribute_assignment_spec.rb
+++ b/spec/record/attribute_assignment_spec.rb
@@ -17,14 +17,6 @@ describe LHS::Record do
     end
   end
 
-  context '#attributes=' do
-    it 'sets the attributes' do
-      entry = LocalEntry.new
-      entry.attributes = { company_name: 'localsearch' }
-      expect(entry.company_name).to eq 'localsearch'
-    end
-  end
-
   context 'when not a hash was passed' do
     it 'raises an error' do
       entry = LocalEntry.new


### PR DESCRIPTION
`assign_attributes` has been introduced as minor (non-breaking).

As this does not seem to be the case, this patch, removes the breaking part, leaves it up to @zhublik to either add it in a non breaking change (patch), or breaking one (major) afterwards, but for now, this PR patches the current version.