### PR TITLE
Expose Header Information

### DIFF
--- a/lib/lhs/item.rb
+++ b/lib/lhs/item.rb
@@ -54,6 +54,6 @@ class LHS::Item < LHS::Proxy
     return _data unless _record.item_key
     nested_data = _data.dig(*_record.item_key)
     return _data unless nested_data
-    nested_data
+    LHS::Data.new(nested_data, _data._parent, _record, _data._request, _data._endpoint)
   end
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.4.0'
+  VERSION = '19.4.1'
 end

--- a/spec/record/item_key_spec.rb
+++ b/spec/record/item_key_spec.rb
@@ -22,12 +22,12 @@ describe LHS::Record do
   end
 
   let(:stub_request_by_id) do
-    stub_request(:get, "http://uberall/location/1")
+    stub_request(:get, 'http://uberall/location/1')
       .to_return(body: location_response)
   end
 
   let(:stub_request_by_get_parameters) do
-    stub_request(:get, "http://uberall/location?identifier=1&limit=1")
+    stub_request(:get, 'http://uberall/location?identifier=1&limit=1')
       .to_return(body: location_response)
   end
 
@@ -49,12 +49,12 @@ describe LHS::Record do
     end
 
     let(:stub_location_by_id) do
-      stub_request(:get, "http://uberall/location/1")
+      stub_request(:get, 'http://uberall/location/1')
         .to_return(headers: { 'X-Custom-Header' => 'rspec' }, body: location_response)
     end
 
     let(:stub_account_by_id) do
-      stub_request(:get, "http://yext/account/1")
+      stub_request(:get, 'http://yext/account/1')
         .to_return(headers: { 'X-Custom-Header' => 'rspec' }, body: account_response)
     end
 


### PR DESCRIPTION
## Bugfix

### Given
```
    class Location < LHS::Record
      configuration item_key: [:response, :location]
      endpoint 'http://uberall/location'
      endpoint 'http://uberall/location/{id}'
    end
```
A `LHS::Record` which configures a `item_key`.

### Before

We would lose associated information (like the _request object)

### After

We preserve associated information (like the _request object)