### PR TITLE
Where with href

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,20 @@ Record.where(accociation_id: '12345')
 GET https://service.example.com/accociation/12345/records
 ```
 
-If the provided parameter – `accociation_id` in this case – is part of the endpoint path, it will be injected into the path:
+If the provided parameter – `accociation_id` in this case – is part of the endpoint path, it will be injected into the path.
+
+You can also provide hrefs to fetch multiple records:
+
+```ruby
+# app/controllers/some_controller.rb
+
+Record.where('https://service.example.com/accociation/12345/records')
+
+```
+```
+GET https://service.example.com/accociation/12345/records
+```
+
 
 #### Reuse/Dry where statements: Use scopes
 

--- a/lib/lhs.rb
+++ b/lib/lhs.rb
@@ -19,6 +19,8 @@ module LHS
     'lhs/endpoint'
   autoload :Inspect,
     'lhs/concerns/inspect'
+  autoload :IsHref,
+    'lhs/concerns/is_href'
   autoload :Item,
     'lhs/item'
   autoload :Pagination,

--- a/lib/lhs/concerns/is_href.rb
+++ b/lib/lhs/concerns/is_href.rb
@@ -7,7 +7,6 @@ module LHS
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def href?(input)
         input.is_a?(String) && %r{^https?://}.match(input).present?
       end

--- a/lib/lhs/concerns/is_href.rb
+++ b/lib/lhs/concerns/is_href.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'active_support'
+
+module LHS
+  module IsHref
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+
+      def href?(input)
+        input.is_a?(String) && %r{^https?://}.match(input).present?
+      end
+    end
+  end
+end

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -14,8 +14,12 @@ class LHS::Record
     end
 
     module ClassMethods
-      def where(hash = nil)
-        Chain.new(self, Parameter.new(hash))
+      def where(args = nil)
+        if href?(args)
+          Chain.new(self, Option.new(url: args))
+        else
+          Chain.new(self, Parameter.new(args))
+        end
       end
 
       def fetch
@@ -200,8 +204,12 @@ class LHS::Record
       end
       alias validate valid?
 
-      def where(hash = nil)
-        push(Parameter.new(hash))
+      def where(args = nil)
+        if LHS::Record.href?(args)
+          push(Option.new(url: args))
+        else
+          push(Parameter.new(args))
+        end
       end
 
       def all(hash = nil)

--- a/lib/lhs/concerns/record/find.rb
+++ b/lib/lhs/concerns/record/find.rb
@@ -81,10 +81,6 @@ class LHS::Record
           options
         end
       end
-
-      def href?(str)
-        str.is_a?(String) && %r{^https?://}.match(str)
-      end
     end
   end
 end

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -62,6 +62,7 @@ class LHS::Record
   include Find
   include FindBy
   include First
+  include LHS::IsHref
   include Last
   include LHS::Inspect
   include Mapping

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.4.1'
+  VERSION = '19.5.0.pre.wherehref.1'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.5.0.pre.wherehref.1'
+  VERSION = '19.5.0'
 end

--- a/spec/record/where_spec.rb
+++ b/spec/record/where_spec.rb
@@ -30,5 +30,33 @@ describe LHS::Record do
       stub_request(:get, "#{datastore}/content-ads/123/feedbacks?campaign_id=456").to_return(status: 200, body: [].to_json)
       Record.where(campaign_id: '123', params: { campaign_id: '456' })
     end
+
+    context 'where with href' do
+      let(:return_body) { [ email: 'steve@local.ch' ].to_json }
+
+      context 'chain initialization' do
+        before do
+          stub_request(:get, "https://localch-accounts/?from_user_id=123")
+            .to_return(body: return_body)
+        end
+
+        it 'queries api with provided href' do
+          records = Record.where('https://localch-accounts?from_user_id=123').fetch
+          expect(records.first.email).to eq 'steve@local.ch'
+        end
+      end
+
+      context 'after chain initialization' do
+        before do
+          stub_request(:get, "https://localch-accounts/?color=blue&from_user_id=123")
+            .to_return(body: return_body)
+        end
+
+        it 'queries api with provided href also when passed after chain is initialized' do
+          records = Record.where(color: 'blue').where('https://localch-accounts?from_user_id=123').fetch
+          expect(records.first.email).to eq 'steve@local.ch'
+        end
+      end
+    end
   end
 end

--- a/spec/record/where_spec.rb
+++ b/spec/record/where_spec.rb
@@ -32,7 +32,7 @@ describe LHS::Record do
     end
 
     context 'where with href' do
-      let(:return_body) { [ email: 'steve@local.ch' ].to_json }
+      let(:return_body) { [ email: 'steve@local.ch'].to_json }
 
       context 'chain initialization' do
         before do

--- a/spec/record/where_spec.rb
+++ b/spec/record/where_spec.rb
@@ -32,7 +32,7 @@ describe LHS::Record do
     end
 
     context 'where with href' do
-      let(:return_body) { [ email: 'steve@local.ch'].to_json }
+      let(:return_body) { [email: 'steve@local.ch'].to_json }
 
       context 'chain initialization' do
         before do


### PR DESCRIPTION
_MINOR_

While `find` was always able to fetch single records by provided href, `where` did not implement that functionality.

This PR adds the ability to pass an href to `where` and fetch a collection of records that way.

This is gonna be used in Customer Center for the user list, where we have to use `next` and `previous` links to navigate the user pagination.

### From the documentation (addition):

You can also provide hrefs to fetch multiple records:

 ```ruby
# app/controllers/some_controller.rb
 Record.where('https://service.example.com/accociation/12345/records')
 ```
```
GET https://service.example.com/accociation/12345/records
```
