### PR TITLE
Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ record.review # "Lunch was great
          * [Endpoints](#endpoints)
             * [Configure endpoint hosts](#configure-endpoint-hosts)
             * [Endpoint Priorities](#endpoint-priorities)
+         * [Provider](#provider)
          * [Record inheritance](#record-inheritance)
          * [Find multiple records](#find-multiple-records)
             * [fetch](#fetch)
@@ -259,6 +260,44 @@ GET https://service.example.com/records
 ```
 
 **Be aware that, if you configure ambigious endpoints accross multiple classes, the order of things is not deteministic. Ambigious endpoints accross multiple classes need to be avoided.**
+
+### Provider
+
+Providers in LHS allow you to group shared endpoint options under a common provider.
+
+```ruby
+# app/models/provider/base_record.rb
+
+module Provider
+  class BaseRecord < LHS::Record
+    provider params: { api_key: 123 }
+  end
+end
+```
+
+Now every record, part of that particular provider can inherit the provider's `BaseRecord`.
+
+```ruby
+# app/models/provider/account.rb
+
+module Provider
+  class Account < BaseRecord
+    endpoint '{+host}/records'
+    endpoint '{+host}/records/{id}'
+  end
+end
+```
+
+```ruby
+# app/controllers/some_controller.rb
+
+Provider::Account.find(1)
+```
+```
+GET https://provider/records/1?api_key=123
+```
+
+And requests made via those provider records apply the common provider options.
 
 ### Record inheritance
 

--- a/lib/lhs/concerns/record/provider.rb
+++ b/lib/lhs/concerns/record/provider.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/core_ext'
+
+class LHS::Record
+
+  # A provider can define options used for that specific provider
+  module Provider
+    extend ActiveSupport::Concern
+
+    included do
+      class_attribute :provider_options unless defined? provider_options
+      self.provider_options = nil
+    end
+
+    module ClassMethods
+      def provider(options = nil)
+        self.provider_options = options
+      end
+    end
+  end
+end

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -495,7 +495,9 @@ class LHS::Record
         options[:ignored_errors] = ignored_errors if ignored_errors.present?
         options[:params]&.deep_symbolize_keys!
         options[:error_handler] = merge_error_handlers(options[:error_handler]) if options[:error_handler]
-        options = (endpoint.options || {}).deep_merge(options)
+        options = (provider_options || {})
+          .deep_merge(endpoint.options || {})
+          .deep_merge(options)
         options[:url] = compute_url!(options[:params]) unless options.key?(:url)
         merge_explicit_params!(options[:params])
         options.delete(:params) if options[:params]&.empty?

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -33,6 +33,8 @@ class LHS::Record
     'lhs/concerns/record/model'
   autoload :Pagination,
     'lhs/concerns/record/pagination'
+  autoload :Provider,
+    'lhs/concerns/record/provider'
   autoload :Request,
     'lhs/concerns/record/request'
   autoload :Relations,
@@ -69,6 +71,7 @@ class LHS::Record
   include Merge
   include Model
   include Pagination
+  include Provider
   include Request
   include Relations
   include RequestCycleCache

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.7.0'
+  VERSION = '19.8.0'
 end

--- a/spec/record/provider_spec.rb
+++ b/spec/record/provider_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'provider' do
+
+    before do
+      module Provider
+        class BaseRecord < LHS::Record
+          provider params: { api_key: 123 }
+        end
+
+        class Record < Provider::BaseRecord
+          endpoint 'http://provider/records'
+        end
+      end
+
+      class AnotherRecord < LHS::Record
+        endpoint 'http://other_provider/records'
+      end
+
+      stub_request(:get, "http://provider/records?id=1&api_key=123")
+        .to_return(body: { name: 'Steve' }.to_json)
+
+      stub_request(:get, "http://other_provider/records?id=1")
+        .to_return(body: { name: 'Not Steve' }.to_json)
+    end
+
+    it 'applies provider options when making requests to that provider' do
+      record = Provider::Record.find(1)
+      expect(record.name).to eq 'Steve'
+    end
+
+    it 'does not apply provider options when making requests to other records' do
+      Provider::Record.find(1)
+      record = AnotherRecord.find(1)
+      expect(record.name).to eq 'Not Steve'
+    end
+  end
+end


### PR DESCRIPTION
LHS providers allow to share common provider endpoint configuration across records.

### Provider

Providers in LHS allow you to group shared endpoint options under a common provider.

```ruby
# app/models/provider/base_record.rb

module Provider
  class BaseRecord < LHS::Record
    provider params: { api_key: 123 }
  end
end
```

Now every record, part of that particular provider can inherit the provider's `BaseRecord`.

```ruby
# app/models/provider/account.rb

module Provider
  class Account < BaseRecord
    endpoint '{+host}/records'
    endpoint '{+host}/records/{id}'
  end
end
```

```ruby
# app/controllers/some_controller.rb

Provider::Account.find(1)
```
```
GET https://provider/records/1?api_key=123
```

And requests made via those provider records apply the common provider options.