### PR TITLE
Fix raising exception when creating parallel requests

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -26,7 +26,11 @@ class LHS::Record
 
       def deep_merge_with_option_blocks(options)
         return options if LHS::OptionBlocks::CurrentOptionBlock.options.blank?
-        options.deep_merge(LHS::OptionBlocks::CurrentOptionBlock.options)
+        if options.is_a?(Hash)
+          options.deep_merge(LHS::OptionBlocks::CurrentOptionBlock.options)
+        elsif options.is_a?(Array)
+          options.map { |option| option.deep_merge(LHS::OptionBlocks::CurrentOptionBlock.options) }
+        end
       end
 
       def single_request_load_and_merge_remaining_objects!(data, options, endpoint)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.8.0'
+  VERSION = '19.8.1'
 end

--- a/spec/option_blocks/main_spec.rb
+++ b/spec/option_blocks/main_spec.rb
@@ -43,4 +43,13 @@ describe LHS::OptionBlocks do
       expect(LHS::OptionBlocks::CurrentOptionBlock.options).to eq nil
     end
   end
+
+  context 'parallel requests' do
+
+    it 'does not fail merging option blocks for parallel requests' do
+      LHS.options(headers: { 'Tracking-Id': 1 }) do
+        Record.find(1234, 1234)
+      end
+    end
+  end
 end


### PR DESCRIPTION
When option blocks where used with making requests in parallel, the following exception was raised:
```
expected no Exception, got #<NoMethodError: undefined method `deep_merge' for #<Array:0x00007fea275239b0>> with backtrace:
```

Now fixed.