### PR TITLE
Adding href_for

### DIFF
--- a/README.md
+++ b/README.md
@@ -2020,6 +2020,21 @@ With `includes` or `includes_all` (to enforce fetching all remote objects for pa
 
 Including linked resources/records is heavily influenced by [https://guides.rubyonrails.org/active_record_querying.html](https://guides.rubyonrails.org/active_record_querying.html#eager-loading-associations) and you should read it to understand this feature in all it's glory.
 
+#### Generate links from parameters
+
+Sometimes you need to generate full hrefs/urls for records but you just have parameters that describe that record, like the ID.
+
+For those usecases you can use `href_for(params)`:
+
+```ruby
+# app/controllers/some_controller.rb
+
+Presence.create(place: { href: Place.href_for(123) })
+```
+```
+POST '/presences' { place: { href: "http://datastore/places/123" } }
+```
+
 #### Ensure the whole linked collection is included: includes_all
 
 In case endpoints are paginated and you are certain that you'll need all objects of a set and not only the first page/batch, use `includes_all`.

--- a/lib/lhs/concerns/record/href_for.rb
+++ b/lib/lhs/concerns/record/href_for.rb
@@ -8,7 +8,6 @@ class LHS::Record
     extend ActiveSupport::Concern
 
     module ClassMethods
-
       def href_for(args = nil)
         return unless [Integer, String].include?(args.class)
         params = { id: args }

--- a/lib/lhs/concerns/record/href_for.rb
+++ b/lib/lhs/concerns/record/href_for.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'active_support'
+
+class LHS::Record
+
+  module HrefFor
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      
+      def href_for(args = nil)
+        return unless [Integer, String].include?(args.class)
+        params = { id: args }
+        find_endpoint(params).compile(params)
+      end
+    end
+  end
+end

--- a/lib/lhs/concerns/record/href_for.rb
+++ b/lib/lhs/concerns/record/href_for.rb
@@ -8,12 +8,13 @@ class LHS::Record
     extend ActiveSupport::Concern
 
     module ClassMethods
-      
+
       def href_for(args = nil)
         return unless [Integer, String].include?(args.class)
         params = { id: args }
         find_endpoint(params).compile(params)
       end
+      alias url_for href_for
     end
   end
 end

--- a/lib/lhs/record.rb
+++ b/lib/lhs/record.rb
@@ -23,6 +23,8 @@ class LHS::Record
     'lhs/concerns/record/find_by'
   autoload :First,
     'lhs/concerns/record/first'
+  autoload :HrefFor,
+    'lhs/concerns/record/href_for'
   autoload :Last,
     'lhs/concerns/record/last'
   autoload :Mapping,
@@ -64,6 +66,7 @@ class LHS::Record
   include Find
   include FindBy
   include First
+  include HrefFor
   include LHS::IsHref
   include Last
   include LHS::Inspect

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.8.2'
+  VERSION = '19.9.0'
 end

--- a/spec/record/href_for_spec.rb
+++ b/spec/record/href_for_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  before do
+    class Record < LHS::Record
+      endpoint 'http://datastore/records/'
+      endpoint 'http://datastore/records/{id}'
+    end
+  end
+
+  context 'href_for' do
+
+    it 'injects variables and returns href' do
+      expect(Record.href_for(1)).to eq 'http://datastore/records/1'
+    end
+  end
+end

--- a/spec/record/href_for_spec.rb
+++ b/spec/record/href_for_spec.rb
@@ -14,6 +14,12 @@ describe LHS::Record do
 
     it 'injects variables and returns href' do
       expect(Record.href_for(1)).to eq 'http://datastore/records/1'
+      expect(Record.href_for('vmasd241')).to eq 'http://datastore/records/vmasd241'
+    end
+
+    it 'also works with url_for (alias)' do
+      expect(Record.url_for(1)).to eq 'http://datastore/records/1'
+      expect(Record.url_for('vmasd241')).to eq 'http://datastore/records/vmasd241'
     end
   end
 end


### PR DESCRIPTION
_MINOR_

#### Generate links from parameters

Sometimes you need to generate full hrefs/urls for records but you just have parameters that describe that record, like the ID.

For those usecases you can use `href_for(params)`:

```ruby
# app/controllers/some_controller.rb

Presence.create(place: { href: Place.href_for(123) })
```
```
POST '/presences' { place: { href: "http://datastore/places/123" } }
```