### PR TITLE
this fixes: `Module#parent` has been renamed to `module_parent`

### DIFF
--- a/Gemfile.activesupport6
+++ b/Gemfile.activesupport6
@@ -1,0 +1,4 @@
+source 'https://rubygems.org/'
+
+gemspec
+gem 'activesupport', '~> 6.0.0.rc2'

--- a/cider-ci/jobs/rspec-activesupport-6.yml
+++ b/cider-ci/jobs/rspec-activesupport-6.yml
@@ -13,7 +13,7 @@ rspec-active-support-v6:
 
     task_defaults:
       environment_variables:
-        ACTIVESUPPORT: '5'
+        ACTIVESUPPORT: '6'
       max_trials: 2
       dispatch_storm_delay_duration: 1 Seconds
       include:

--- a/cider-ci/jobs/rspec-activesupport-6.yml
+++ b/cider-ci/jobs/rspec-activesupport-6.yml
@@ -1,0 +1,26 @@
+rspec-active-support-v6:
+  name: 'rspec with ActiveSupport v6'
+
+  run_when:
+    'some HEAD has been updated':
+      type: branch
+      include_match: ^.*$
+
+  context:
+
+    script_defaults:
+      template_environment_variables: true
+
+    task_defaults:
+      environment_variables:
+        ACTIVESUPPORT: '5'
+      max_trials: 2
+      dispatch_storm_delay_duration: 1 Seconds
+      include:
+        - cider-ci/task_components/ruby.yml
+        - cider-ci/task_components/bundle.yml
+        - cider-ci/task_components/rspec.yml
+
+    tasks:
+      all-rspec:
+        name: All rspec tests, using ActiveSupport v6

--- a/lib/lhs/concerns/inspect.rb
+++ b/lib/lhs/concerns/inspect.rb
@@ -37,8 +37,8 @@ module LHS
     end
 
     def _collect_parents_for_inspect!(path, current)
-      return unless current.parent
-      parent_raw = current.parent._raw
+      return unless current.module_parent
+      parent_raw = current.module_parent._raw
       if parent_raw.is_a?(Array)
         parent_raw.each_with_index do |element, index|
           path.push(index) if element == current._raw
@@ -48,7 +48,7 @@ module LHS
           path.push(key) if value == current._raw
         end
       end
-      _collect_parents_for_inspect!(path, current.parent)
+      _collect_parents_for_inspect!(path, current.module_parent)
     end
 
     def pretty_raw

--- a/lib/lhs/concerns/inspect.rb
+++ b/lib/lhs/concerns/inspect.rb
@@ -38,6 +38,8 @@ module LHS
 
     def _collect_parents_for_inspect!(path, current)
       module_parent = respond_to?(:module_parent) ? current.module_parent : current.parent
+      return unless module_parent
+
       parent_raw = module_parent._raw
       if parent_raw.is_a?(Array)
         parent_raw.each_with_index do |element, index|

--- a/lib/lhs/concerns/inspect.rb
+++ b/lib/lhs/concerns/inspect.rb
@@ -37,8 +37,8 @@ module LHS
     end
 
     def _collect_parents_for_inspect!(path, current)
-      return unless current.module_parent
-      parent_raw = current.module_parent._raw
+      module_parent = respond_to?(:module_parent) ? current.module_parent : current.parent
+      parent_raw = module_parent._raw
       if parent_raw.is_a?(Array)
         parent_raw.each_with_index do |element, index|
           path.push(index) if element == current._raw
@@ -48,7 +48,7 @@ module LHS
           path.push(key) if value == current._raw
         end
       end
-      _collect_parents_for_inspect!(path, current.module_parent)
+      _collect_parents_for_inspect!(path, module_parent)
     end
 
     def pretty_raw

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.10.0'
+  VERSION = '19.10.1'
 end


### PR DESCRIPTION
this adds compatibility for rails 6, which emits a deprecation warning about `Module#parent`