### PR TITLE
The simple lhs/rspec test helper approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -2520,17 +2520,18 @@ it 'displays contracts' do
 end
 ```
 
-### Test helper for request cycle cache
+### Test helper
 
-In order to not run into caching issues during your tests, when (request cycle cache)[#request-cycle-cache] is enabled, simply require the following helper in your tests:
+In order to load LHS test helpers into your tests, add the following to your spec helper:
 
 ```ruby
 # spec/spec_helper.rb
 
-require 'lhs/test/request_cycle_cache_helper'
+require 'lhs/rspec'
 ```
 
-This will initialize a MemoryStore cache for LHC::Caching interceptor and resets the cache before every test.
+This e.g. will prevent running into caching issues during your tests, when (request cycle cache)[#request-cycle-cache] is enabled.
+It will initialize a MemoryStore cache for LHC::Caching interceptor and resets the cache before every test.
 
 ### Test query chains
 

--- a/lib/lhs/rspec.rb
+++ b/lib/lhs/rspec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'lhs'
+
 RSpec.configure do |config|
   config.before(:each) do
     LHS.config.request_cycle_cache.clear

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '19.10.0'
+  VERSION = '20.0.0'
 end


### PR DESCRIPTION
This follows the simple approach of loading a specific gems test helper in its entirety, instead of needing to know internals and individual test class files.

This is generally performed by a lot of standard gems out there, like webmock, capybara etc. and already has been introduced to LHC here: https://github.com/local-ch/lhc#testing

_MAJOR_

## Migration Path

Replace 
```ruby
require 'lhs/test/request_cycle_cache_helper'
```

With:
```ruby
require 'lhs/rspec'
```