### PR TITLE
Fix rspec stub override

### DIFF
--- a/lib/lhs/rspec.rb
+++ b/lib/lhs/rspec.rb
@@ -7,4 +7,13 @@ RSpec.configure do |config|
   config.before(:each) do
     LHS.config.request_cycle_cache.clear
   end
+
+  config.before(:all) do
+
+    module LHS
+      def self.stub
+        LHS::Test::Stub
+      end
+    end
+  end
 end

--- a/lib/lhs/test/stub.rb
+++ b/lib/lhs/test/stub.rb
@@ -26,8 +26,4 @@ module LHS
       end
     end
   end
-
-  def self.stub
-    @stub ||= Test::Stub
-  end
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '20.1.0'
+  VERSION = '20.1.1'
 end

--- a/spec/stubs/all_spec.rb
+++ b/spec/stubs/all_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'lhs/rspec'
 
-describe LHS::Test::Stub do
+describe LHS do
 
   before do
     class Record < LHS::Record


### PR DESCRIPTION
Unfortunately in an app, when loading lhs and rspec independently, rspec "patches" all objects/modules in the test context, and adds their own "stub" method to it, including the "LHS" namespace.

This PR shifts the LHS.stub definition to be initialized after rspec is done with messing around.

Unfortunately I didn't find a way to test that from within LHS 🤷‍♂ 