### PR TITLE
LHS require missing dependency

### DIFF
--- a/lib/lhs/concerns/option_blocks.rb
+++ b/lib/lhs/concerns/option_blocks.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support'
+require 'active_support/per_thread_registry'
 
 module LHS
   module OptionBlocks

--- a/lib/lhs/interceptors/extended_rollbar/thread_registry.rb
+++ b/lib/lhs/interceptors/extended_rollbar/thread_registry.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support'
+require 'active_support/per_thread_registry'
 
 module LHS
   module Interceptors

--- a/lib/lhs/interceptors/request_cycle_cache/thread_registry.rb
+++ b/lib/lhs/interceptors/request_cycle_cache/thread_registry.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'active_support'
+require 'active_support/per_thread_registry'
 
 module LHS
   module Interceptors

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '20.1.1'
+  VERSION = '20.1.2'
 end


### PR DESCRIPTION
in some constellation this dependency was not autoloaded anymore. make the require explicit.

I am not able to create the exact same scenario for a test. What I do know:

- `lcl` crashes with `uninitialized constant ActiveSupport::PerThreadRegistry (NameError)`
- this fix when applied to the locally used lhs, solved my issue
- I assume the issue starts happening when the application context uses rails 6. but i could not reproduce the error when using activesupport 6 in LHS, something else is amiss :-(