### PR TITLE
Include nested data that's nested in structures

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -246,7 +246,7 @@ class LHS::Record
       def skip_loading_includes?(data, included)
         if data.collection?
           data.to_a.none? { |item| item[included].present? }
-        elsif data[included].href.blank?
+        elsif data[included].item? && data[included].href.blank?
           true
         else
           !data._raw.key?(included)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -246,7 +246,7 @@ class LHS::Record
       def skip_loading_includes?(data, included)
         if data.collection?
           data.to_a.none? { |item| item[included].present? }
-        elsif data[included].item? && data[included].href.blank?
+        elsif data[included].present? && data[included].item? && data[included].href.blank?
           true
         else
           !data._raw.key?(included)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '21.2.0'
+  VERSION = '21.2.1'
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -636,4 +636,33 @@ describe LHS::Record do
       expect(records.alternative_categories.first.name).to eq 'blue'
     end
   end
+
+  context 'nested within another structure' do
+    before do
+      class Place < LHS::Record
+        endpoint 'https://places/{id}'
+      end
+      stub_request(:get, "https://places/1")
+        .to_return(body: {
+          customer: {
+            salesforce: {
+              href: 'https://salesforce/customers/1'
+            }
+          }
+        }.to_json)
+    end
+
+    let!(:nested_request) do
+      stub_request(:get, "https://salesforce/customers/1")
+        .to_return(body: {
+          name: 'Steve'
+        }.to_json)
+    end
+
+    it 'includes data that has been nested in an additional structure' do
+      place = Place.includes({ customer: :salesforce }).find(1)
+      expect(nested_request).to have_been_requested
+      expect(place.customer.salesforce.name).to eq 'Steve'
+    end
+  end
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -660,7 +660,7 @@ describe LHS::Record do
     end
 
     it 'includes data that has been nested in an additional structure' do
-      place = Place.includes({ customer: :salesforce }).find(1)
+      place = Place.includes(customer: :salesforce).find(1)
       expect(nested_request).to have_been_requested
       expect(place.customer.salesforce.name).to eq 'Steve'
     end


### PR DESCRIPTION
This enables us to load nested linked data, even if it has been nested in unlinked structures:

Upcoming place change:
```
{
  "customer": {
    "salesforce": {
      "href": "https://salesforce/customers/1"
    }
  }
}
```

`customer` itself is not a linked resource on it's own, it's just another structure/namespace.

Previously LHS tried to load that namespace when you would instruct it to load the salesforce customer
```
Place.includes(customer: :salesforce).find(1)
# raised an exception
```

Now LHS skips the namespace `customer` as it does not have an `href` and therefore does not need to be loaded.