### PR TITLE
prevent exception when including nested nothing

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -176,7 +176,7 @@ class LHS::Record
         else
           handle_include(includes, data, nil, references[includes])
         end
-        data.clear_cache! # as we just included new nested resources
+        data.clear_cache! if data.present? # as we just included new nested resources
       end
 
       def handle_include(included, data, sub_includes = nil, reference = nil)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '21.2.1'
+  VERSION = '21.2.2'
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -665,4 +665,22 @@ describe LHS::Record do
       expect(place.customer.salesforce.name).to eq 'Steve'
     end
   end
+
+  context 'include empty structures' do
+    before do
+      class Place < LHS::Record
+        endpoint 'https://places/{id}'
+      end
+      stub_request(:get, "https://places/1")
+        .to_return(body: {
+          id: '123'
+        }.to_json)
+    end
+
+    it 'skips includes when there is nothing and also does not raise an exception' do
+      expect(->{
+        Place.includes({ contracts: :product }).find(1)
+      }).not_to raise_exception
+    end
+  end
 end

--- a/spec/record/includes_spec.rb
+++ b/spec/record/includes_spec.rb
@@ -678,8 +678,8 @@ describe LHS::Record do
     end
 
     it 'skips includes when there is nothing and also does not raise an exception' do
-      expect(->{
-        Place.includes({ contracts: :product }).find(1)
+      expect(-> {
+        Place.includes(contracts: :product).find(1)
       }).not_to raise_exception
     end
   end


### PR DESCRIPTION
Implementing `handle_skip_include` here https://github.com/local-ch/lhs/pull/376/files#diff-ffbc06effcbee79e18771740f1ba521bR194 made nested includes of not existing data run into this issue/exception.

This patches the case where include is skipped, by preventing access of the none existing data.