### PR TITLE
fix for providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ record.review # "Lunch was great
      * [Change store for LHS' request cycle cache](#change-store-for-lhs-request-cycle-cache)
      * [Disable request cycle cache](#disable-request-cycle-cache)
   * [Automatic Authentication (OAuth)](#automatic-authentication-oauth)
+     * [Configure providers](#configure-providers)
      * [Configure multiple auth providers (even per endpoint)](#configure-multiple-auth-providers-even-per-endpoint)
   * [Option Blocks](#option-blocks)
   * [Request tracing](#request-tracing)
@@ -147,6 +148,7 @@ record.review # "Lunch was great
         * [By explicitly resolving the chain: fetch](#by-explicitly-resolving-the-chain-fetch)
         * [Without resolving the chain: where_values_hash](#without-resolving-the-chain-where_values_hash)
   * [License](#license)
+
 
 
 
@@ -2505,6 +2507,22 @@ Record.find(1)
 ```
 https://records/1
 Authentication: 'Bearer token-12345'
+```
+
+### Configure providers
+
+If you're using LHS service providers, you can also configure auto auth on a provider level:
+
+```ruby
+# app/models/providers/localsearch.rb
+module Providers
+  class Localsearch < LHS::Record
+    
+    provider(
+      auto_oauth: true
+    )
+  end
+end
 ```
 
 ### Configure multiple auth providers (even per endpoint)

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ record.review # "Lunch was great
      * [Change store for LHS' request cycle cache](#change-store-for-lhs-request-cycle-cache)
      * [Disable request cycle cache](#disable-request-cycle-cache)
   * [Automatic Authentication (OAuth)](#automatic-authentication-oauth)
-     * [Configure providers](#configure-providers)
      * [Configure multiple auth providers (even per endpoint)](#configure-multiple-auth-providers-even-per-endpoint)
+     * [Configure providers](#configure-providers)
   * [Option Blocks](#option-blocks)
   * [Request tracing](#request-tracing)
   * [Extended Rollbar Logging](#extended-rollbar-logging)
@@ -2509,22 +2509,6 @@ https://records/1
 Authentication: 'Bearer token-12345'
 ```
 
-### Configure providers
-
-If you're using LHS service providers, you can also configure auto auth on a provider level:
-
-```ruby
-# app/models/providers/localsearch.rb
-module Providers
-  class Localsearch < LHS::Record
-    
-    provider(
-      auto_oauth: true
-    )
-  end
-end
-```
-
 ### Configure multiple auth providers (even per endpoint)
 
 In case you need to configure multiple auth provider access_tokens within your application,
@@ -2560,6 +2544,36 @@ or on an endpoint level:
 class Record < LHS::Record
   endpoint 'https://service/records', oauth: :provider1
   #...
+end
+```
+
+### Configure providers
+
+If you're using LHS service providers, you can also configure auto auth on a provider level:
+
+```ruby
+# app/models/providers/localsearch.rb
+module Providers
+  class Localsearch < LHS::Record
+    
+    provider(
+      oauth: true
+    )
+  end
+end
+```
+
+or with multiple auth providers:
+
+```ruby
+# app/models/providers/localsearch.rb
+module Providers
+  class Localsearch < LHS::Record
+    
+    provider(
+      oauth: :provider_1
+    )
+  end
 end
 ```
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -532,7 +532,7 @@ class LHS::Record
         end
 
         endpoint = find_endpoint(options[:params], options.fetch(:url, nil))
-        if auto_oauth? || (endpoint.options&.dig(:oauth) && LHS.config.auto_oauth) || options[:auto_oauth]
+        if auto_oauth? || (endpoint.options&.dig(:oauth) && LHS.config.auto_oauth) || options[:oauth]
           inject_interceptor!(
             options.merge!(record: self),
             LHS::Interceptors::AutoOauth::Interceptor,

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -532,7 +532,7 @@ class LHS::Record
         end
 
         endpoint = find_endpoint(options[:params], options.fetch(:url, nil))
-        if auto_oauth? || (endpoint.options&.dig(:oauth) && LHS.config.auto_oauth)
+        if auto_oauth? || (endpoint.options&.dig(:oauth) && LHS.config.auto_oauth) || options[:auto_oauth]
           inject_interceptor!(
             options.merge!(record: self),
             LHS::Interceptors::AutoOauth::Interceptor,

--- a/lib/lhs/interceptors/auto_oauth/interceptor.rb
+++ b/lib/lhs/interceptors/auto_oauth/interceptor.rb
@@ -21,7 +21,6 @@ module LHS
           if tokens.is_a?(Hash)
             tokens.dig(
               request.options[:oauth] ||
-              request.options[:auto_oauth] ||
               request.options[:record]&.auto_oauth
             )
           else

--- a/lib/lhs/interceptors/auto_oauth/interceptor.rb
+++ b/lib/lhs/interceptors/auto_oauth/interceptor.rb
@@ -21,6 +21,7 @@ module LHS
           if tokens.is_a?(Hash)
             tokens.dig(
               request.options[:oauth] ||
+              request.options[:auto_oauth] ||
               request.options[:record]&.auto_oauth
             )
           else

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '21.3.0'
+  VERSION = '21.3.1'
 end

--- a/spec/dummy/app/controllers/automatic_authentication_controller.rb
+++ b/spec/dummy/app/controllers/automatic_authentication_controller.rb
@@ -19,4 +19,11 @@ class AutomaticAuthenticationController < ApplicationController
       }
     }
   end
+
+  def o_auth_with_provider
+    render json: {
+      record: DummyRecordWithAutoOauthProvider.find(1).as_json,
+      records: DummyRecordWithAutoOauthProvider.where(color: 'blue').as_json
+    }
+  end
 end

--- a/spec/dummy/app/models/dummy_record_with_auto_oauth_provider.rb
+++ b/spec/dummy/app/models/dummy_record_with_auto_oauth_provider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DummyRecordWithAutoOauthProvider < Providers::InternalServices
   endpoint 'http://internalservice/v2/records'
   endpoint 'http://internalservice/v2/records/{id}'

--- a/spec/dummy/app/models/dummy_record_with_auto_oauth_provider.rb
+++ b/spec/dummy/app/models/dummy_record_with_auto_oauth_provider.rb
@@ -1,0 +1,4 @@
+class DummyRecordWithAutoOauthProvider < Providers::InternalServices
+  endpoint 'http://internalservice/v2/records'
+  endpoint 'http://internalservice/v2/records/{id}'
+end

--- a/spec/dummy/app/models/providers/internal_services.rb
+++ b/spec/dummy/app/models/providers/internal_services.rb
@@ -2,6 +2,6 @@
 
 module Providers
   class InternalServices < LHS::Record
-    provider(auto_oauth: true)
+    provider(oauth: true)
   end
 end

--- a/spec/dummy/app/models/providers/internal_services.rb
+++ b/spec/dummy/app/models/providers/internal_services.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Providers
+  class InternalServices < LHS::Record
+    provider(auto_oauth: true)
+  end
+end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # Automatic Authentication
   get 'automatic_authentication/oauth' => 'automatic_authentication#o_auth'
   get 'automatic_authentication/oauth_with_multiple_providers' => 'automatic_authentication#o_auth_with_multiple_providers'
+  get 'automatic_authentication/oauth_with_provider' => 'automatic_authentication#o_auth_with_provider'
 
   # Request Cycle Cache
   get 'request_cycle_cache/simple' => 'request_cycle_cache#simple'


### PR DESCRIPTION
While trying to implement auto oauth into the new localsearch app, I realized that providers have not been supported for auto oauth.

This PR changes this and adds auto oauth athentication for providers:

### Configure providers

If you're using LHS service providers, you can also configure auto auth on a provider level:

```ruby
# app/models/providers/localsearch.rb
module Providers
  class Localsearch < LHS::Record
    
    provider(
      oauth: true
    )
  end
end
```

or with multiple auth providers:

```ruby
# app/models/providers/localsearch.rb
module Providers
  class Localsearch < LHS::Record
    
    provider(
      oauth: :provider_1
    )
  end
end
```