### PR TITLE
Fix auto expand included

### DIFF
--- a/README.md
+++ b/README.md
@@ -2279,6 +2279,17 @@ In parallel:
   GET https://service.example.com/places/4 { headers: { 'Authentication': 'Bearer 123' } }
 ```
 
+Here is another example if you want to ignore errors occuring while you fetch included resources:
+
+```ruby
+# app/controllers/some_controller.rb
+
+feedback = Feedback
+  .includes(campaign: :entry)
+  .references(campaign: { ignored_errors: [LHC::NotFound] })
+  .find(12345)
+```
+
 ### Record batch processing
 
 **Be careful using methods for batch processing. They could result in a lot of HTTP requests!**

--- a/README.md
+++ b/README.md
@@ -2279,7 +2279,7 @@ In parallel:
   GET https://service.example.com/places/4 { headers: { 'Authentication': 'Bearer 123' } }
 ```
 
-Here is another example if you want to ignore errors occuring while you fetch included resources:
+Here is another example, if you want to ignore errors, that occure while you fetch included resources:
 
 ```ruby
 # app/controllers/some_controller.rb

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel'
   s.add_dependency 'activesupport', '>= 4.2.11'
-  s.add_dependency 'lhc', '>= 10', '< 12'
+  s.add_dependency 'lhc', '>= 11.2.0', '< 12'
   s.add_dependency 'local_uri'
 
   s.add_development_dependency 'capybara'

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -346,7 +346,7 @@ class LHS::Record
       end
 
       # Load additional resources that are requested with include
-      def load_include(options, data, sub_includes, references)
+      def load_include(options, _data, sub_includes, references)
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         prepare_options_for_include_request!(options, sub_includes, references)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -205,7 +205,7 @@ class LHS::Record
       def expand_addition!(data, included, reference)
         addition = data[included]
         options = options_for_data(addition)
-        options = extend_with_reference(options, reference.except(:url))
+        options = extend_with_reference(options, reference)
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         expanded_data = record.request(options)
@@ -217,7 +217,7 @@ class LHS::Record
         if addition.item?
           (addition._raw.keys - [:href]).any?
         elsif addition.collection?
-          addition.all? do |item|
+          addition.any? do |item|
             next if item.blank?
             if item._raw.is_a?(Hash)
               (item._raw.keys - [:href]).any?
@@ -230,7 +230,8 @@ class LHS::Record
 
       # Extends request options with options provided for this reference
       def extend_with_reference(options, reference)
-        return options unless reference
+        return options if reference.blank?
+        referene = reference.except(:url)
         options ||= {}
         if options.is_a?(Array)
           options.map { |request_options| request_options.merge(reference) if request_options.present? }

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -138,6 +138,7 @@ class LHS::Record
       end
 
       def extend_base_item!(data, addition, key)
+        return if addition.nil?
         if addition.collection?
           extend_base_item_with_collection!(data, addition, key)
         else # simple case merges hash into hash
@@ -231,7 +232,7 @@ class LHS::Record
       # Extends request options with options provided for this reference
       def extend_with_reference(options, reference)
         return options if reference.blank?
-        referene = reference.except(:url)
+        reference = reference.except(:url)
         options ||= {}
         if options.is_a?(Array)
           options.map { |request_options| request_options.merge(reference) if request_options.present? }
@@ -365,7 +366,7 @@ class LHS::Record
 
       def load_include_simple!(options, record)
         data = record.request(options)
-        warn "[WARNING] You included `#{options[:url]}`, but this endpoint is paginated. You might want to use `includes_all` instead of `includes` (https://github.com/local-ch/lhs#includes_all-for-paginated-endpoints)." if paginated?(data._raw)
+        warn "[WARNING] You included `#{options[:url]}`, but this endpoint is paginated. You might want to use `includes_all` instead of `includes` (https://github.com/local-ch/lhs#includes_all-for-paginated-endpoints)." if data && paginated?(data._raw)
         data
       end
 

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '23.0.0.pre'
+  VERSION = '23.0.0'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '22.1.1.pre'
+  VERSION = '23.0.0.pre'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '22.1.0'
+  VERSION = '22.1.1'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '22.1.1'
+  VERSION = '22.1.1.pre'
 end

--- a/spec/record/includes_first_page_spec.rb
+++ b/spec/record/includes_first_page_spec.rb
@@ -224,7 +224,7 @@ describe LHS::Record do
   end
 
   context 'links pointing to nowhere' do
-    it 'sets nil for links that cannot be included' do
+    before do
       class Feedback < LHS::Record
         endpoint '{+datastore}/feedbacks'
         endpoint '{+datastore}/feedbacks/{id}'
@@ -238,10 +238,20 @@ describe LHS::Record do
 
       stub_request(:get, "#{datastore}/content-ads/51dfc5690cf271c375c5a12d")
         .to_return(status: 404)
+    end
 
-      feedback = Feedback.includes_first_page(campaign: :entry).find(123)
-      expect(feedback.campaign._raw.keys.count).to eq 1
-      expect(feedback.campaign.href).to be_present
+    it 'raises LHC::NotFound for links that cannot be included' do
+      expect(-> {
+        Feedback.includes_first_page(campaign: :entry).find(123)
+      }).to raise_error LHC::NotFound
+    end
+
+    it 'ignores LHC::NotFound for links that cannot be included if configured so with reference options' do
+      feedback = Feedback
+        .includes_first_page(campaign: :entry)
+        .references(campaign: { ignored_errors: [LHC::NotFound] })
+        .find(123)
+      expect(feedback.campaign.first.keys.length).to eq 1
     end
   end
 

--- a/spec/record/includes_first_page_spec.rb
+++ b/spec/record/includes_first_page_spec.rb
@@ -251,7 +251,7 @@ describe LHS::Record do
         .includes_first_page(campaign: :entry)
         .references(campaign: { ignored_errors: [LHC::NotFound] })
         .find(123)
-      expect(feedback.campaign.first.keys.length).to eq 1
+      expect(feedback.campaign._raw.keys).to eq 1
     end
   end
 

--- a/spec/record/includes_first_page_spec.rb
+++ b/spec/record/includes_first_page_spec.rb
@@ -251,7 +251,7 @@ describe LHS::Record do
         .includes_first_page(campaign: :entry)
         .references(campaign: { ignored_errors: [LHC::NotFound] })
         .find(123)
-      expect(feedback.campaign._raw.keys).to eq 1
+      expect(feedback.campaign._raw.keys.length).to eq 1
     end
   end
 


### PR DESCRIPTION
MAJOR

LHS and LHC were meant to raise errors in case of unexpected network responses, like 404 (anything but 20X basically).

We had some trouble including nested linked resources in the new localsearch app when some of them were leading to a 404.

Because LHS was catching `LHC::NotFound` internally, it ,by accident, didn't include any resources at all, if there were loaded in batches/in parallel.

See: https://github.com/local-ch/lhs/pull/386/files#diff-ffbc06effcbee79e18771740f1ba521bL211

This PR changes the way LHS reacts in case of request errors while including nested resources. It does not skip them anymore, but raises them, which also allows people to control an includes behaviour for response issues while requesting the includes.

See: https://github.com/local-ch/lhs/pull/386/files#diff-649867ca8a2b60723ed21762863861f9R252

Migration:

In case you want to ignore errors errors for errors raised during including nested resources, use `references` in combination with LHC's option `ignored_errors`:

```ruby
feedback = Feedback
  .includes(campaign: :entry)
  .references(campaign: { ignored_errors: [LHC::NotFound] })
  .find(12345)
```