### PR TITLE
Ignore and rescue lhc

### DIFF
--- a/README.md
+++ b/README.md
@@ -979,7 +979,7 @@ If you need to render some different view in Rails based on an LHS error raised 
 
 def show
   @records = Record
-    .handle(LHC::Error, ->(error){ handle_error(error) })
+    .rescue(LHC::Error, ->(error){ rescue_from(error) })
     .where(color: 'blue')
   render 'show'
   render_error if @error
@@ -987,7 +987,7 @@ end
 
 private
 
-def handle_error(error)
+def rescue_from(error)
   @error = error
   nil
 end
@@ -1012,7 +1012,7 @@ If you want to inject values for the failing records, that might not have been f
 # app/controllers/some_controller.rb
 
 data = Record
-  .handle(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
+  .rescue(LHC::Unauthorized, ->(response) { Record.new(name: 'unknown') })
   .find(1, 2, 3)
 
 data[1].name # 'unknown'
@@ -2286,7 +2286,7 @@ Here is another example, if you want to ignore errors, that occure while you fet
 
 feedback = Feedback
   .includes(campaign: :entry)
-  .references(campaign: { ignored_errors: [LHC::NotFound] })
+  .references(campaign: { ignore: LHC::NotFound })
   .find(12345)
 ```
 

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel'
   s.add_dependency 'activesupport', '>= 4.2.11'
-  s.add_dependency 'lhc', '>= 11.2.0', '< 12'
+  s.add_dependency 'lhc', '>= 12', '< 13'
   s.add_dependency 'local_uri'
 
   s.add_development_dependency 'capybara'

--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'activemodel'
   s.add_dependency 'activesupport', '>= 4.2.11'
-  s.add_dependency 'lhc', '>= 12', '< 13'
+  s.add_dependency 'lhc', '>= 12.1.1', '< 13'
   s.add_dependency 'local_uri'
 
   s.add_development_dependency 'capybara'

--- a/lib/lhs/concerns/record/chainable.rb
+++ b/lib/lhs/concerns/record/chainable.rb
@@ -52,7 +52,7 @@ class LHS::Record
         Chain.new(self, Pagination.new(per: argument))
       end
 
-      def handle(error_class, handler)
+      def rescue(error_class, handler)
         Chain.new(self, ErrorHandling.new(error_class => handler))
       end
 
@@ -255,7 +255,7 @@ class LHS::Record
         push(Pagination.new(per: argument))
       end
 
-      def handle(error_class, handler)
+      def rescue(error_class, handler)
         push(ErrorHandling.new(error_class => handler))
       end
 
@@ -348,8 +348,8 @@ class LHS::Record
       def resolved_options
         options = chain_options
         options = options.deep_merge(params: chain_parameters.merge(chain_pagination))
-        options = options.merge(error_handler: chain_error_handler) if chain_error_handler.present?
-        options = options.merge(ignored_errors: chain_ignored_errors) if chain_ignored_errors.present?
+        options = options.merge(rescue: chain_error_handler) if chain_error_handler.present?
+        options = options.merge(ignore: chain_ignored_errors) if chain_ignored_errors.present?
         options = options.merge(including: chain_includes) if chain_includes.present?
         options = options.merge(referencing: chain_references) if chain_references.present?
         options

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -504,7 +504,7 @@ class LHS::Record
         options = options.deep_dup
         options[:ignored_errors] = ignored_errors if ignored_errors.present?
         options[:params]&.deep_symbolize_keys!
-        options[:error_handler] = merge_error_handlers(options[:error_handler]) if options[:error_handler]
+        options[:rescue] = merge_error_handlers(options[:rescue]) if options[:rescue]
         options = (provider_options || {})
           .deep_merge(endpoint.options || {})
           .deep_merge(options)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '23.0.0'
+  VERSION = '24.0.0'
 end

--- a/spec/dummy/app/controllers/error_handling_with_chains_controller.rb
+++ b/spec/dummy/app/controllers/error_handling_with_chains_controller.rb
@@ -6,7 +6,7 @@ class ErrorHandlingWithChainsController < ApplicationController
   # in the view (during render 'show')
   def fetch_in_view
     @records = DummyRecord
-      .handle(LHC::Error, ->(error) { handle_error(error) })
+      .rescue(LHC::Error, ->(error) { handle_error(error) })
       .where(color: 'blue')
     render 'show'
     render_error if @error
@@ -16,7 +16,7 @@ class ErrorHandlingWithChainsController < ApplicationController
   # before the view is rendered
   def fetch_in_controller
     @records = DummyRecord
-      .handle(LHC::Error, ->(error) { handle_error(error) })
+      .rescue(LHC::Error, ->(error) { handle_error(error) })
       .where(color: 'blue').fetch
     render 'show'
     render_error if @error

--- a/spec/record/error_handling_spec.rb
+++ b/spec/record/error_handling_spec.rb
@@ -15,14 +15,14 @@ describe LHS::Record do
 
   it 'allows to chain error handling' do
     expect {
-      Record.where(color: 'blue').handle(LHC::Error, ->(_error) { handler.handle }).first
+      Record.where(color: 'blue').rescue(LHC::Error, ->(_error) { handler.handle }).first
     }.not_to raise_error
     expect(handler).to have_received(:handle)
   end
 
   it 'reraises in case chained error is not matched' do
     expect {
-      Record.where(color: 'blue').handle(LHC::Conflict, ->(_error) { handler.handle }).first
+      Record.where(color: 'blue').rescue(LHC::Conflict, ->(_error) { handler.handle }).first
     }.to raise_error(LHC::Error)
     expect(handler).not_to have_received(:handle)
   end
@@ -30,8 +30,8 @@ describe LHS::Record do
   it 'calls all the handlers' do
     expect {
       Record.where(color: 'blue')
-        .handle(LHC::Error, ->(_error) { handler.handle_1 })
-        .handle(LHC::Error, ->(_error) { handler.handle_2 })
+        .rescue(LHC::Error, ->(_error) { handler.handle_1 })
+        .rescue(LHC::Error, ->(_error) { handler.handle_2 })
         .first
     }.not_to raise_error
     expect(handler).to have_received(:handle_1)

--- a/spec/record/find_in_parallel_spec.rb
+++ b/spec/record/find_in_parallel_spec.rb
@@ -33,7 +33,7 @@ describe LHS::Record do
     it 'applies error handlers from the chain and returns whatever the error handler returns' do
       stub_request(:get, "http://datastore/records/2").to_return(status: 401)
       data = Record
-        .handle(LHC::Unauthorized, ->(_response) { Record.new(name: 'unknown') })
+        .rescue(LHC::Unauthorized, ->(_response) { Record.new(name: 'unknown') })
         .find(1, 2, 3)
       expect(data[1].name).to eq 'unknown'
     end

--- a/spec/record/handle_includes_errors_spec.rb
+++ b/spec/record/handle_includes_errors_spec.rb
@@ -25,7 +25,7 @@ describe LHS::Record do
 
   it 'allows to pass error_handling for includes to LHC' do
     handler = ->(_) { return { deleted: true } }
-    record = Record.includes_first_page(:other).references(other: { error_handler: { LHC::NotFound => handler } }).find(id: 1)
+    record = Record.includes_first_page(:other).references(other: { rescue: { LHC::NotFound => handler } }).find(id: 1)
 
     expect(record.other.deleted).to be(true)
   end

--- a/spec/record/includes_first_page_spec.rb
+++ b/spec/record/includes_first_page_spec.rb
@@ -249,7 +249,7 @@ describe LHS::Record do
     it 'ignores LHC::NotFound for links that cannot be included if configured so with reference options' do
       feedback = Feedback
         .includes_first_page(campaign: :entry)
-        .references(campaign: { ignored_errors: [LHC::NotFound] })
+        .references(campaign: { ignore: [LHC::NotFound] })
         .find(123)
       expect(feedback.campaign._raw.keys.length).to eq 1
     end


### PR DESCRIPTION
LHC renamed `ignored_errors` to `ignore` and `error_handler` to `rescue`.

This PR bumps LHC and changes internal naming of using those LHC actions/options.

This PR also renames `handle` to `rescue` and  to stick with the naming.

MAJOR