### PR TITLE
compact: Remove included resources that didn't return any records

### DIFF
--- a/README.md
+++ b/README.md
@@ -2292,7 +2292,7 @@ feedback = Feedback
 
 #### compact: Remove included resources that didn't return any records
 
-In case you include nested data and ignored errors while including, you can get back a collection with data based on response errors:
+In case you include nested data and ignored errors while including, it can happen that you get back a collection that contains data based on response errors:
 
 ```ruby
 # app/controllers/some_controller.rb
@@ -2324,7 +2324,7 @@ GET http://service/places/2
 user.places[1] # { "status": 404, "error": "not found" }
 ```
 
-In order to exclude items from a collection that where not based on successful responses, use `.compact` or `.compact!`:
+In order to exclude items from a collection which where not based on successful responses, use `.compact` or `.compact!`:
 
 ```ruby
 # app/controllers/some_controller.rb
@@ -2337,7 +2337,6 @@ places = user.places.compact
 
 places # { "items": [ { "href": "http://service/places/1", "name": "Casa Ferlin" } ] }
 ```
-
 
 ### Record batch processing
 

--- a/lib/lhs/concerns/collection/internal_collection.rb
+++ b/lib/lhs/concerns/collection/internal_collection.rb
@@ -35,16 +35,16 @@ class LHS::Collection < LHS::Proxy
           end
         end
       end
-      
+
       def compact
-        self.dup.tap do |collection|
+        dup.tap do |collection|
           return if collection.raw.nil?
           collection.compact!
         end
       end
 
       def compact!
-        self.raw = self.raw.map do |item|
+        self.raw = raw.map do |item|
           if item.is_a?(LHS::Data) && item._request && !item._request.response.success?
             nil
           else

--- a/lib/lhs/concerns/collection/internal_collection.rb
+++ b/lib/lhs/concerns/collection/internal_collection.rb
@@ -14,7 +14,7 @@ class LHS::Collection < LHS::Proxy
 
       attr_accessor :raw
       delegate :length, :size, :first, :last, :sample, :[], :present?, :blank?, :empty?,
-               :<<, :push, :compact, to: :raw
+               :<<, :push, to: :raw
 
       def initialize(raw, parent, record)
         self.raw = raw
@@ -34,6 +34,23 @@ class LHS::Collection < LHS::Proxy
             yield item
           end
         end
+      end
+      
+      def compact
+        self.dup.tap do |collection|
+          return if collection.raw.nil?
+          collection.compact!
+        end
+      end
+
+      def compact!
+        self.raw = self.raw.map do |item|
+          if item.is_a?(LHS::Data) && item._request && !item._request.response.success?
+            nil
+          else
+            item
+          end
+        end.compact
       end
 
       private

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -7,14 +7,14 @@ class LHS::Data
   module Extend
     extend ActiveSupport::Concern
 
-    # Extends already fetched data (self) with additionally 
+    # Extends already fetched data (self) with additionally
     # fetched data (addition) using the given key
     def extend!(addition, key)
-      if self.collection?
+      if collection?
         extend_collection!(addition, key)
       elsif self[key]._raw.is_a? Array
         extend_array!(addition, key)
-      elsif self.item?
+      elsif item?
         extend_item!(addition, key)
       end
     end
@@ -22,7 +22,7 @@ class LHS::Data
     private
 
     def extend_collection!(addition, key)
-      self.map do |item|
+      map do |item|
         item_raw = item._raw[key]
         item_raw.blank? ? [nil] : item_raw
       end
@@ -50,7 +50,7 @@ class LHS::Data
       if addition.collection?
         extend_item_with_collection!(addition, key)
       else # simple case merges hash into hash
-        self._raw[key.to_sym].merge!(addition._raw)
+        _raw[key.to_sym].merge!(addition._raw)
       end
     end
 
@@ -66,7 +66,7 @@ class LHS::Data
     def extend_item_with_hash_containing_items!(target, addition)
       LHS::Collection.nest(input: target._raw, value: [], record: self) # inits the nested collection
       if LHS::Collection.access(input: target._raw, record: self).empty?
-        LHS::Collection.nest(input: target._raw, value: addition.reject{|item| item.nil?}, record: self)
+        LHS::Collection.nest(input: target._raw, value: addition.reject { |item| item.nil? }, record: self)
       else
         LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
           item.merge!(addition[index])

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'active_support'
+
+class LHS::Data
+
+  module Extend
+    extend ActiveSupport::Concern
+
+    # Extends already fetched data (self) with additionally 
+    # fetched data (addition) using the given key
+    def extend!(addition, key)
+      binding.pry
+      if self.collection?
+        extend_collection!(addition, key)
+      elsif self[key]._raw.is_a? Array
+        extend_array!(addition, key)
+      elsif self.item?
+        extend_item!(addition, key)
+      end
+    end
+
+    private
+
+    def extend_collection!(addition, key)
+      self.map do |item|
+        item_raw = item._raw[key]
+        item_raw.blank? ? [nil] : item_raw
+      end
+        .flatten
+        .each_with_index do |item, index|
+          item_addition = addition[index]
+          next if item_addition.nil? || item.nil?
+          if item_addition._raw.is_a?(Array)
+            item[items_key] ||= []
+            item[items_key].concat(item_addition._raw)
+          else
+            item.merge! item_addition._raw
+          end
+        end
+    end
+
+    def extend_array!(addition, key)
+      self[key].zip(addition) do |item, additional_item|
+        item._raw.merge!(additional_item._raw) if additional_item.present?
+      end
+    end
+
+    def extend_item!(addition, key)
+      return if addition.nil?
+      if addition.collection?
+        extend_item_with_collection!(addition, key)
+      else # simple case merges hash into hash
+        self._raw[key.to_sym].merge!(addition._raw)
+      end
+    end
+
+    def extend_item_with_collection!(addition, key)
+      target = self[key]
+      if target._raw.is_a? Array
+        self[key] = addition.map(&:_raw)
+      else # hash with items
+        extend_item_with_hash_containing_items!(target, addition)
+      end
+    end
+
+    def extend_item_with_hash_containing_items!(target, addition)
+      LHS::Collection.nest(input: target._raw, value: [], record: self) # inits the nested collection
+      if LHS::Collection.access(input: target._raw, record: self).empty?
+
+        LHS::Collection.nest(input: target._raw, value: addition.compact.map(&:_raw), record: self)
+      else
+        LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
+          item.merge!(addition[index])
+        end
+      end
+    end
+  end
+end

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -10,7 +10,6 @@ class LHS::Data
     # Extends already fetched data (self) with additionally 
     # fetched data (addition) using the given key
     def extend!(addition, key)
-      binding.pry
       if self.collection?
         extend_collection!(addition, key)
       elsif self[key]._raw.is_a? Array
@@ -67,8 +66,7 @@ class LHS::Data
     def extend_item_with_hash_containing_items!(target, addition)
       LHS::Collection.nest(input: target._raw, value: [], record: self) # inits the nested collection
       if LHS::Collection.access(input: target._raw, record: self).empty?
-
-        LHS::Collection.nest(input: target._raw, value: addition.compact.map(&:_raw), record: self)
+        LHS::Collection.nest(input: target._raw, value: addition.reject{|item| item.nil?}, record: self)
       else
         LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
           item.merge!(addition[index])

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -6,6 +6,8 @@ class LHS::Data
     'lhs/concerns/data/becomes'
   autoload :Equality,
     'lhs/concerns/data/equality'
+  autoload :Extend,
+    'lhs/concerns/data/extend'
   autoload :Json,
     'lhs/concerns/data/json'
   autoload :ToHash,
@@ -13,6 +15,7 @@ class LHS::Data
 
   include Becomes
   include Equality
+  include Extend
   include Json
   include ToHash
   include LHS::Inspect

--- a/lib/lhs/data.rb
+++ b/lib/lhs/data.rb
@@ -33,6 +33,7 @@ class LHS::Data
     self._proxy = proxy_from_input(input)
     self._request = request
     self._endpoint = endpoint
+    preserve_input_requests!(input)
   end
 
   # merging data
@@ -99,6 +100,17 @@ class LHS::Data
   end
 
   private
+
+  def preserve_input_requests!(input)
+    if input.is_a?(LHS::Data)
+      _request = input._request if _request.nil?
+    elsif input.is_a?(Array) && input.first.is_a?(LHS::Data)
+      input.each_with_index do |item, index|
+        next if item.nil?
+        self[index]._request = item._request
+      end
+    end
+  end
 
   def collection_proxy?(input)
     (input.is_a?(Hash) && LHS::Collection.access(input: input, record: _record)) ||

--- a/spec/record/compact_spec.rb
+++ b/spec/record/compact_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'removes unsuccsessful linked resouces' do
+    before do
+      class Place < LHS::Record
+        endpoint 'http://datastore/places/{id}'
+      end
+
+      class User < LHS::Record
+        endpoint 'http://datastore/users/{id}'
+      end
+
+      stub_request(:get, 'http://datastore/users/123')
+        .to_return(status: 200, body: {
+          href: 'http://datastore/users/123',
+          places: { href: 'http://datastore/users/123/places' }
+        }.to_json)
+
+      stub_request(:get, 'http://datastore/users/123/places?limit=100')
+        .to_return(status: 200, body: {
+          href: 'http://datastore/users/123/places?offset=0&limit=100',
+          items: [
+            {
+              href: 'http://datastore/users/123/places/789'
+            }
+          ],
+          total: 4,
+          offset: 0,
+          limit: 10
+        }.to_json)
+
+      stub_request(:get, 'http://datastore/users/123/places/789?limit=100')
+        .to_return(
+          status: 404,
+          body: {
+            status: 404,
+            message: 'The requested resource does not exist.'
+          }.to_json
+      )
+    end
+
+    it 'removes linked resouces which could not get fetched' do
+      places = User 
+        .includes(:places)
+        .references(places: { ignore: LHC::NotFound })
+        .find('123')
+        .places
+        .compact
+      expect(places.length).to eq 0
+    end
+  end
+end

--- a/spec/record/compact_spec.rb
+++ b/spec/record/compact_spec.rb
@@ -38,12 +38,12 @@ describe LHS::Record do
           status: 404,
           message: 'The requested resource does not exist.'
         }.to_json
-    )
+      )
 
   end
 
   let(:places) do
-    User 
+    User
       .includes(:places)
       .references(places: { ignore: LHC::NotFound })
       .find('123')

--- a/spec/record/compact_spec.rb
+++ b/spec/record/compact_spec.rb
@@ -3,53 +3,65 @@
 require 'rails_helper'
 
 describe LHS::Record do
-  context 'removes unsuccsessful linked resouces' do
-    before do
-      class Place < LHS::Record
-        endpoint 'http://datastore/places/{id}'
-      end
-
-      class User < LHS::Record
-        endpoint 'http://datastore/users/{id}'
-      end
-
-      stub_request(:get, 'http://datastore/users/123')
-        .to_return(status: 200, body: {
-          href: 'http://datastore/users/123',
-          places: { href: 'http://datastore/users/123/places' }
-        }.to_json)
-
-      stub_request(:get, 'http://datastore/users/123/places?limit=100')
-        .to_return(status: 200, body: {
-          href: 'http://datastore/users/123/places?offset=0&limit=100',
-          items: [
-            {
-              href: 'http://datastore/users/123/places/789'
-            }
-          ],
-          total: 4,
-          offset: 0,
-          limit: 10
-        }.to_json)
-
-      stub_request(:get, 'http://datastore/users/123/places/789?limit=100')
-        .to_return(
-          status: 404,
-          body: {
-            status: 404,
-            message: 'The requested resource does not exist.'
-          }.to_json
-      )
+  before do
+    class Place < LHS::Record
+      endpoint 'http://datastore/places/{id}'
     end
 
+    class User < LHS::Record
+      endpoint 'http://datastore/users/{id}'
+    end
+
+    stub_request(:get, 'http://datastore/users/123')
+      .to_return(status: 200, body: {
+        href: 'http://datastore/users/123',
+        places: { href: 'http://datastore/users/123/places' }
+      }.to_json)
+
+    stub_request(:get, 'http://datastore/users/123/places?limit=100')
+      .to_return(status: 200, body: {
+        href: 'http://datastore/users/123/places?offset=0&limit=100',
+        items: [
+          {
+            href: 'http://datastore/users/123/places/789'
+          }
+        ],
+        total: 4,
+        offset: 0,
+        limit: 10
+      }.to_json)
+
+    stub_request(:get, 'http://datastore/users/123/places/789?limit=100')
+      .to_return(
+        status: 404,
+        body: {
+          status: 404,
+          message: 'The requested resource does not exist.'
+        }.to_json
+    )
+
+  end
+
+  let(:places) do
+    User 
+      .includes(:places)
+      .references(places: { ignore: LHC::NotFound })
+      .find('123')
+      .places
+  end
+
+  context '.compact' do
+
     it 'removes linked resouces which could not get fetched' do
-      places = User 
-        .includes(:places)
-        .references(places: { ignore: LHC::NotFound })
-        .find('123')
-        .places
-        .compact
-      expect(places.length).to eq 0
+      expect(places.compact.length).to eq 0
+      expect(places.length).not_to eq 0 # leaves the original intact
+    end
+  end
+
+  context '.compact!' do
+    it 'removes linked resouces which could not get fetched' do
+      expect(places.compact!.length).to eq 0
+      expect(places.length).to eq 0 # and changes the original intact
     end
   end
 end

--- a/spec/record/includes_first_page_spec.rb
+++ b/spec/record/includes_first_page_spec.rb
@@ -253,14 +253,6 @@ describe LHS::Record do
         .find(123)
       expect(feedback.campaign._raw.keys.length).to eq 1
     end
-
-    it 'excludes LHC::NotFound for links that cannot be included if configured so with reference options' do
-      feedback = Feedback
-        .includes_first_page(campaign: :entry)
-        .references(campaign: { compact: [LHC::NotFound] })
-        .find(123)
-      expect(feedback.campaign._raw.keys.length).to eq 0
-    end
   end
 
   context 'modules' do

--- a/spec/record/includes_first_page_spec.rb
+++ b/spec/record/includes_first_page_spec.rb
@@ -253,6 +253,14 @@ describe LHS::Record do
         .find(123)
       expect(feedback.campaign._raw.keys.length).to eq 1
     end
+
+    it 'excludes LHC::NotFound for links that cannot be included if configured so with reference options' do
+      feedback = Feedback
+        .includes_first_page(campaign: :entry)
+        .references(campaign: { compact: [LHC::NotFound] })
+        .find(123)
+      expect(feedback.campaign._raw.keys.length).to eq 0
+    end
   end
 
   context 'modules' do


### PR DESCRIPTION
Implements `compact` and `compact!` into `LHS::Collection::InternalCollection`.

Also refactors extending data by moving it from bloated `request.rb` to a proper concern of `LHS::Data`.

#### compact: Remove included resources that didn't return any records

In case you include nested data and ignored errors while including, it can happen that you get back a collection that contains data based on response errors:

```ruby
# app/controllers/some_controller.rb

user = User
  .includes(:places)
  .references(places: { ignore: LHC::NotFound })
  .find(123)
```

```
GET http://service/users/123
{ "places": { "href": "http://service/users/123/places" } }

GET http://service/users/123/places
{ "items": [
  { "href": "http://service/places/1" },
  { "href": "http://service/places/2" }
] }

GET http://service/places/1
200 { "name": "Casa Ferlin" }

GET http://service/places/2
404 { "status": 404, "error": "not found" }
```

```ruby
user.places[1] # { "status": 404, "error": "not found" }
```

In order to exclude items from a collection which where not based on successful responses, use `.compact` or `.compact!`:

```ruby
# app/controllers/some_controller.rb

user = User
  .includes(:places)
  .references(places: { ignore: LHC::NotFound })
  .find(123)
places = user.places.compact

places # { "items": [ { "href": "http://service/places/1", "name": "Casa Ferlin" } ] }
```