### PR TITLE
Pass reference not options

### DIFF
--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -120,7 +120,8 @@ class LHS::Record
           options = extend_with_reference(options, reference)
           addition = load_include(options, data, sub_includes, reference)
           data.extend!(addition, included)
-          expand_addition!(data, included, options) unless expanded_data?(addition)
+          binding.pry
+          expand_addition!(data, included, reference) unless expanded_data?(addition)
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -120,7 +120,7 @@ class LHS::Record
           options = extend_with_reference(options, reference)
           addition = load_include(options, data, sub_includes, reference)
           data.extend!(addition, included)
-          expand_addition!(data, included, options, reference) unless expanded_data?(addition)
+          expand_addition!(data, included, reference) unless expanded_data?(addition)
         end
       end
 
@@ -135,7 +135,7 @@ class LHS::Record
         url_option_for(data, included)
       end
 
-      def expand_addition!(data, included, options, reference)
+      def expand_addition!(data, included, reference)
         addition = data[included]
         options = options_for_data(addition)
         options = extend_with_reference(options, reference)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -120,7 +120,7 @@ class LHS::Record
           options = extend_with_reference(options, reference)
           addition = load_include(options, data, sub_includes, reference)
           data.extend!(addition, included)
-          expand_addition!(data, included, reference) unless expanded_data?(addition)
+          expand_addition!(data, included, options, reference) unless expanded_data?(addition)
         end
       end
 
@@ -135,7 +135,7 @@ class LHS::Record
         url_option_for(data, included)
       end
 
-      def expand_addition!(data, included, reference)
+      def expand_addition!(data, included, options, reference)
         addition = data[included]
         options = options_for_data(addition)
         options = extend_with_reference(options, reference)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -120,7 +120,6 @@ class LHS::Record
           options = extend_with_reference(options, reference)
           addition = load_include(options, data, sub_includes, reference)
           data.extend!(addition, included)
-          binding.pry
           expand_addition!(data, included, reference) unless expanded_data?(addition)
         end
       end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '24.1.1'
+  VERSION = '24.1.2'
 end

--- a/spec/record/compact_spec.rb
+++ b/spec/record/compact_spec.rb
@@ -38,7 +38,7 @@ describe LHS::Record do
         limit: 10
       }.to_json)
 
-    stub_request(:get, 'http://datastore/users/123/places/789?limit=100')
+    stub_request(:get, 'http://datastore/users/123/places/789')
       .to_return(
         body: {
           href: 'http://datastore/users/123/places/789?limit=100',
@@ -46,7 +46,7 @@ describe LHS::Record do
         }.to_json
       )
 
-    stub_request(:get, 'http://datastore/users/123/places/790?limit=100')
+    stub_request(:get, 'http://datastore/users/123/places/790')
       .to_return(
         status: 404,
         body: {

--- a/spec/record/includes_expanded_spec.rb
+++ b/spec/record/includes_expanded_spec.rb
@@ -32,6 +32,6 @@ describe LHS::Record do
       expect(
         record.car.name
       ).to eq 'wrum wrum'
-    end  
+    end
   end
 end

--- a/spec/record/includes_expanded_spec.rb
+++ b/spec/record/includes_expanded_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'includes all (expanded)' do
+    before do
+      class Record < LHS::Record
+        endpoint 'http://records/{id}'
+      end
+
+      stub_request(:get, "http://records/1")
+        .to_return(
+          body: {
+            car: { href: 'http://records/1/car' }
+          }.to_json
+        )
+
+      stub_request(:get, "http://records/1/car?color=blue&limit=100")
+        .to_return(
+          body: { href: 'http://records/cars/1' }.to_json
+        )
+
+      stub_request(:get, "http://records/cars/1?color=blue&limit=100")
+        .to_return(
+          body: { name: 'wrum wrum' }.to_json
+        )
+    end
+
+    it 'expands linked resources and forwards proper reference' do
+      record = Record.includes(:car).references(car: { params: { color: :blue } }).find(1)
+      expect(
+        record.car.name
+      ).to eq 'wrum wrum'
+    end  
+  end
+end

--- a/spec/record/references_spec.rb
+++ b/spec/record/references_spec.rb
@@ -76,7 +76,7 @@ describe LHS::Record do
           }.to_json
         )
 
-        stub_request(:get, 'http://datastore/customers/1/users/1?limit=100')
+        stub_request(:get, 'http://datastore/customers/1/users/1')
           .with(headers: { 'Authentication' => 'Bearer 123' })
           .to_return(body: { href: 'http://datastore/users/1', name: 'Elizabeth Baker' }.to_json)
       end


### PR DESCRIPTION
There was wrong passing of `options` instead of `reference` deep inside some of the handle includes internal in cases includes where not pre expanded :atom: 🚀 .

This might accidentally passed `?limit=100` to some included requests, that you need to remove again in your specs.