### PR TITLE
Fix autoloading of inheriting records

### DIFF
--- a/lib/lhs/concerns/autoload_records.rb
+++ b/lib/lhs/concerns/autoload_records.rb
@@ -41,7 +41,7 @@ module AutoloadRecords
 
         def self.require_inheriting_records(parents)
           model_files.each do |file|
-            next if parents.none? { |parent| File.read(file).match(parent) }
+            next if parents.none? { |parent| File.read(file).match(/\b#{parent}\b/) }
             require_dependency file
           end
         end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '25.0.0'
+  VERSION = '25.1.0'
 end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '25.1.0'
+  VERSION = '25.0.1'
 end


### PR DESCRIPTION
# Description
The issue i faced during the update of `LHS` for `location_app` (some content was stripped on purpose):
```ruby
# app/models/data_layer/favorites.rb

class DataLayer
  class ListType
    def build
      if favorites?
        'Favorites'
      end
    end
  end
end
```
such file will be loaded automatically when there is the following class: `class Favorite < LHS::Record; end`

This PR changes the regexp to more restrict and might match only the whole word(s).

P.S. Not sure how to test this behaviour since the file i put inside `spec/dummy/app/models` will be loaded when tests are executed.