### PR TITLE
prevent autoloading concerns

### DIFF
--- a/lib/lhs/concerns/autoload_records.rb
+++ b/lib/lhs/concerns/autoload_records.rb
@@ -32,7 +32,7 @@ module AutoloadRecords
         end
 
         def self.require_direct_inheritance
-          model_files.map do |file|
+          model_files.sort.map do |file|
             next unless File.read(file).match('LHS::Record')
             require_dependency file
             file.split('models/').last.gsub('.rb', '').classify
@@ -41,7 +41,9 @@ module AutoloadRecords
 
         def self.require_inheriting_records(parents)
           model_files.each do |file|
-            next if parents.none? { |parent| File.read(file).match(/\b#{parent}\b/) }
+            file_content = File.read(file)
+            next if parents.none? { |parent| file_content.match(/\b#{parent}\b/) }
+            next if file_content.match?('extend ActiveSupport::Concern')
             require_dependency file
           end
         end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '25.0.1'
+  VERSION = '25.0.2'
 end

--- a/spec/dummy/app/models/concerns/dummy_customer/some_concern.rb
+++ b/spec/dummy/app/models/concerns/dummy_customer/some_concern.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class DummyCustomer < Providers::CustomerSystem
+  module SomeConcern
+    extend ActiveSupport::Concern
+
+    # dont auto load this again with LHS as it would raise an exception
+    
+  end
+end

--- a/spec/dummy/app/models/concerns/dummy_customer/some_concern.rb
+++ b/spec/dummy/app/models/concerns/dummy_customer/some_concern.rb
@@ -5,6 +5,5 @@ class DummyCustomer < Providers::CustomerSystem
     extend ActiveSupport::Concern
 
     # dont auto load this again with LHS as it would raise an exception
-    
   end
 end

--- a/spec/dummy/app/models/dummy_customer.rb
+++ b/spec/dummy/app/models/dummy_customer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class DummyCustomer < Providers::CustomerSystem
+  include SomeConcern
   endpoint 'http://customers'
   endpoint 'http://customers/{id}'
 end


### PR DESCRIPTION
some applications were showing weird behavior when using concerns for lhs records. 

e.g. causing 

```
TypeError:
       superclass mismatch for class Place
```


Turns out that was because autoloading was autoloading those concerns, even though they are not lhs's business. ruby/rails takes care of autoloading them when loading the original records.

This PR fixes that issue. Unfortunately there was no way of adding a test for that (i've tried) but that issue has been described also by Dima here: https://github.com/local-ch/lhs/pull/397