### PR TITLE
Fix loading missing includes

### DIFF
--- a/lib/lhs/collection.rb
+++ b/lib/lhs/collection.rb
@@ -14,7 +14,7 @@ class LHS::Collection < LHS::Proxy
 
   METHOD_NAMES_EXLCUDED_FROM_WRAPPING = %w(to_a to_ary map).freeze
 
-  delegate :select, :length, :size, to: :_collection
+  delegate :select, :length, :size, :insert, to: :_collection
   delegate :_record, :_raw, to: :_data
   delegate :limit, :count, :total, :offset, :current_page, :start,
            :next?, :previous?, to: :_pagination

--- a/lib/lhs/concerns/collection/internal_collection.rb
+++ b/lib/lhs/concerns/collection/internal_collection.rb
@@ -14,7 +14,7 @@ class LHS::Collection < LHS::Proxy
 
       attr_accessor :raw
       delegate :length, :size, :first, :last, :sample, :[], :present?, :blank?, :empty?,
-               :<<, :push, to: :raw
+               :<<, :push, :insert, to: :raw
 
       def initialize(raw, parent, record)
         self.raw = raw

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -280,18 +280,18 @@ class LHS::Record
         end
       end
 
-      def load_existing_includes(options, _data, sub_includes, references)
-        if _data.collection?
+      def load_existing_includes(options, data, sub_includes, references)
+        if data.collection?
           # filter only existing items
-          loaded_includes = load_include(options.compact, _data.compact, sub_includes, references)
+          loaded_includes = load_include(options.compact, data.compact, sub_includes, references)
           # fill up skipped items before returning
-          _data.each_with_index do |item, index|
+          data.each_with_index do |item, index|
             next if item.present?
             loaded_includes.insert(index, {})
           end
           loaded_includes
         else
-          load_include(options, _data, sub_includes, references)
+          load_include(options, data, sub_includes, references)
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -281,7 +281,7 @@ class LHS::Record
       end
 
       def load_existing_includes(options, data, sub_includes, references)
-        if data.collection?
+        if data.collection? && data.any?(&:blank?)
           # filter only existing items
           loaded_includes = load_include(options.compact, data.compact, sub_includes, references)
           # fill up skipped items before returning

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -29,7 +29,10 @@ class LHS::Record
         if options.is_a?(Hash)
           options.deep_merge(LHS::OptionBlocks::CurrentOptionBlock.options)
         elsif options.is_a?(Array)
-          options.map { |option| option.deep_merge(LHS::OptionBlocks::CurrentOptionBlock.options) }
+          options.map do |option|
+            return LHS::OptionBlocks::CurrentOptionBlock.options unless option
+            option.deep_merge(LHS::OptionBlocks::CurrentOptionBlock.options)
+          end
         end
       end
 
@@ -118,7 +121,7 @@ class LHS::Record
         else
           options = options_for_data(data, included)
           options = extend_with_reference(options, reference)
-          addition = load_include(options, data, sub_includes, reference)
+          addition = load_existing_includes(options, data, sub_includes, reference)
           data.extend!(addition, included)
           expand_addition!(data, included, reference) unless expanded_data?(addition)
         end
@@ -274,6 +277,21 @@ class LHS::Record
         end
         data._record.request(options_for_next_batch.flatten).each do |batch_data|
           merge_batch_data_with_parent!(batch_data, data[batch_data._request.options[:merge_with_index]])
+        end
+      end
+
+      def load_existing_includes(options, _data, sub_includes, references)
+        if _data.collection?
+          # filter only existing items
+          loaded_includes = load_include(options.compact, _data.compact, sub_includes, references)
+          # fill up skipped items before returning
+          _data.each_with_index do |item, index|
+            next if item.present?
+            loaded_includes.insert(index, {})
+          end
+          return loaded_includes
+        else
+          load_include(options, _data, sub_includes, references)
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -289,7 +289,7 @@ class LHS::Record
             next if item.present?
             loaded_includes.insert(index, {})
           end
-          return loaded_includes
+          loaded_includes
         else
           load_include(options, _data, sub_includes, references)
         end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '25.0.2'
+  VERSION = '25.0.3'
 end

--- a/spec/record/includes_missing_spec.rb
+++ b/spec/record/includes_missing_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe LHS::Record do
-  
+
   context 'merge request options ' do
     before do
       class Record < LHS::Record
@@ -43,10 +43,10 @@ describe LHS::Record do
 
     context 'missing referenced options due to none existance of include' do
 
-      it 'should not raise when trying to merge options with the options block' do
+      it 'does not raise when trying to merge options with the options block' do
         LHS.options(throttle: { break: '80%' }) do
           record = Record
-            .references({ place_attributes: { group: { params: { status: 'active' } } } })
+            .references(place_attributes: { group: { params: { status: 'active' } } })
             .includes([{ place_attributes: :group }])
             .find(1)
           expect(record.place_attributes[0].group.name).to eq 'General'

--- a/spec/record/includes_missing_spec.rb
+++ b/spec/record/includes_missing_spec.rb
@@ -13,8 +13,9 @@ describe LHS::Record do
       stub_request(:get, 'http://records/1')
         .to_return(body: {
           place_attributes: [
+            { href: 'https://attributes/bar' },
             { href: 'https://attributes/restaurant' },
-            { href: 'https://attributes/bar' }
+            { href: 'https://attributes/cafe' }
           ]
         }.to_json)
 
@@ -28,16 +29,29 @@ describe LHS::Record do
             href: 'https://group/general'
           }
         }.to_json)
+      stub_request(:get, "https://attributes/cafe?limit=100")
+        .to_return(body: {
+          group: {
+            href: 'https://group/general'
+          }
+        }.to_json)
+      stub_request(:get, "https://group/general?limit=100&status=active")
+        .to_return(body: {
+          name: 'General'
+        }.to_json)
     end
 
     context 'missing referenced options due to none existance of include' do
 
       it 'should not raise when trying to merge options with the options block' do
         LHS.options(throttle: { break: '80%' }) do
-          records = Record
+          record = Record
             .references({ place_attributes: { group: { params: { status: 'active' } } } })
             .includes([{ place_attributes: :group }])
             .find(1)
+          expect(record.place_attributes[0].group.name).to eq 'General'
+          expect(record.place_attributes[1].group).to eq nil
+          expect(record.place_attributes[2].group.name).to eq 'General'
         end
       end
     end

--- a/spec/record/includes_missing_spec.rb
+++ b/spec/record/includes_missing_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  
+  context 'merge request options ' do
+    before do
+      class Record < LHS::Record
+        endpoint 'http://records/{id}'
+      end
+
+      stub_request(:get, 'http://records/1')
+        .to_return(body: {
+          place_attributes: [
+            { href: 'https://attributes/restaurant' },
+            { href: 'https://attributes/bar' }
+          ]
+        }.to_json)
+
+      stub_request(:get, "https://attributes/restaurant?limit=100")
+        .to_return(body: {}.to_json)
+      stub_request(:get, "https://attributes/restaurant")
+        .to_return(body: {}.to_json)
+      stub_request(:get, "https://attributes/bar?limit=100")
+        .to_return(body: {
+          group: {
+            href: 'https://group/general'
+          }
+        }.to_json)
+    end
+
+    context 'missing referenced options due to none existance of include' do
+
+      it 'should not raise when trying to merge options with the options block' do
+        LHS.options(throttle: { break: '80%' }) do
+          records = Record
+            .references({ place_attributes: { group: { params: { status: 'active' } } } })
+            .includes([{ place_attributes: :group }])
+            .find(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes an edge case where we include via 2 levels and the second level is missing.

```
 NoMethodError:
       undefined method `deep_merge' for nil:NilClass
     # ./lib/lhs/concerns/record/request.rb:32:in `block in deep_merge_with_option_blocks'
     # ./lib/lhs/concerns/record/request.rb:32:in `map'
     # ./lib/lhs/concerns/record/request.rb:32:in `deep_merge_with_op
```
https://rollbar.com/local.ch/opm/items/98256/
