### PR TITLE
Expand included links

### DIFF
--- a/lib/lhs/concerns/collection/internal_collection.rb
+++ b/lib/lhs/concerns/collection/internal_collection.rb
@@ -39,7 +39,7 @@ class LHS::Collection < LHS::Proxy
       def compact
         dup.tap do |collection|
           collection.compact! if collection.raw.present?
-        end
+        end.as_json # do not return an internal collection!
       end
 
       def compact!

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -9,7 +9,7 @@ class LHS::Data
 
     # Extends already fetched data (self) with additionally
     # fetched data (addition) using the given key
-    def extend!(addition, key=nil)
+    def extend!(addition, key = nil)
       addition = cast_relation_class_for_extension(addition, key)
       if collection?
         extend_collection!(addition, key)
@@ -22,7 +22,7 @@ class LHS::Data
 
     private
 
-    def cast_relation_class_for_extension(addition, key=nil)
+    def cast_relation_class_for_extension(addition, key = nil)
       return addition if _record.nil? || key.nil? || _record._relations.nil? || _record._relations[key].nil?
       addition.becomes(_record._relations[key][:record_class_name].constantize, errors: addition.errors, warnings: addition.warnings)
     end
@@ -45,13 +45,13 @@ class LHS::Data
         end
     end
 
-    def extend_array!(addition, key=nil)
+    def extend_array!(addition, key = nil)
       (key ? self[key] : self).zip(addition) do |item, additional_item|
         item._raw.merge!(additional_item._raw) if additional_item.present?
       end
     end
 
-    def extend_item!(addition, key=nil)
+    def extend_item!(addition, key = nil)
       return if addition.nil?
       if addition.collection?
         extend_item_with_collection!(addition, key)
@@ -60,7 +60,7 @@ class LHS::Data
       end
     end
 
-    def extend_item_with_collection!(addition, key=nil)
+    def extend_item_with_collection!(addition, key = nil)
       target = (key ? self[key] : self)
       if target._raw.is_a? Array
         self[key] = addition.map(&:_raw) if key

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -72,7 +72,11 @@ class LHS::Data
     def extend_item_with_hash_containing_items!(target, addition)
       LHS::Collection.nest(input: target._raw, value: [], record: self) # inits the nested collection
       if LHS::Collection.access(input: target._raw, record: self).empty?
-        LHS::Collection.nest(input: target._raw, value: addition.reject { |item| item.nil? }, record: self)
+        LHS::Collection.nest(
+          input: target._raw,
+          value: addition.reject { |item| item.nil? }.as_json,
+          record: self
+        )
       else
         LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
           item.merge!(addition[index])

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -74,7 +74,7 @@ class LHS::Data
       if LHS::Collection.access(input: target._raw, record: self).empty?
         LHS::Collection.nest(
           input: target._raw,
-          value: addition.reject { |item| item.nil? }.as_json,
+          value: addition.reject { |item| item.nil? },
           record: self
         )
       else

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -13,7 +13,7 @@ class LHS::Data
       addition = cast_relation_class_for_extension(addition, key)
       if collection?
         extend_collection!(addition, key)
-      elsif self[key]._raw.is_a? Array
+      elsif self._raw.is_a?(Array) || self[key]._raw.is_a?(Array)
         extend_array!(addition, key)
       elsif item?
         extend_item!(addition, key)

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -9,11 +9,11 @@ class LHS::Data
 
     # Extends already fetched data (self) with additionally
     # fetched data (addition) using the given key
-    def extend!(addition, key)
+    def extend!(addition, key = nil)
       addition = cast_relation_class_for_extension(addition, key)
       if collection?
         extend_collection!(addition, key)
-      elsif self[key]._raw.is_a? Array
+      elsif _raw.is_a?(Array) || self[key]._raw.is_a?(Array)
         extend_array!(addition, key)
       elsif item?
         extend_item!(addition, key)
@@ -22,14 +22,14 @@ class LHS::Data
 
     private
 
-    def cast_relation_class_for_extension(addition, key)
-      return addition if _record.nil? || _record._relations.nil? || _record._relations[key].nil?
+    def cast_relation_class_for_extension(addition, key = nil)
+      return addition if _record.nil? || key.nil? || _record._relations.nil? || _record._relations[key].nil?
       addition.becomes(_record._relations[key][:record_class_name].constantize, errors: addition.errors, warnings: addition.warnings)
     end
 
-    def extend_collection!(addition, key)
+    def extend_collection!(addition, key = nil)
       map do |item|
-        item_raw = item._raw[key]
+        item_raw = key ? item._raw[key] : item._raw
         item_raw.blank? ? [nil] : item_raw
       end
         .flatten
@@ -45,25 +45,25 @@ class LHS::Data
         end
     end
 
-    def extend_array!(addition, key)
-      self[key].zip(addition) do |item, additional_item|
+    def extend_array!(addition, key = nil)
+      (key ? self[key] : self).zip(addition) do |item, additional_item|
         item._raw.merge!(additional_item._raw) if additional_item.present?
       end
     end
 
-    def extend_item!(addition, key)
+    def extend_item!(addition, key = nil)
       return if addition.nil?
       if addition.collection?
         extend_item_with_collection!(addition, key)
       else # simple case merges hash into hash
-        _raw[key.to_sym].merge!(addition._raw)
+        (key ? _raw[key.to_sym] : _raw).merge!(addition._raw)
       end
     end
 
-    def extend_item_with_collection!(addition, key)
-      target = self[key]
+    def extend_item_with_collection!(addition, key = nil)
+      target = (key ? self[key] : self)
       if target._raw.is_a? Array
-        self[key] = addition.map(&:_raw)
+        self[key] = addition.map(&:_raw) if key
       else # hash with items
         extend_item_with_hash_containing_items!(target, addition)
       end
@@ -72,7 +72,11 @@ class LHS::Data
     def extend_item_with_hash_containing_items!(target, addition)
       LHS::Collection.nest(input: target._raw, value: [], record: self) # inits the nested collection
       if LHS::Collection.access(input: target._raw, record: self).empty?
-        LHS::Collection.nest(input: target._raw, value: addition.reject { |item| item.nil? }, record: self)
+        LHS::Collection.nest(
+          input: target._raw,
+          value: addition.reject { |item| item.nil? }.as_json,
+          record: self
+        )
       else
         LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
           item.merge!(addition[index])

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -9,11 +9,11 @@ class LHS::Data
 
     # Extends already fetched data (self) with additionally
     # fetched data (addition) using the given key
-    def extend!(addition, key = nil)
+    def extend!(addition, key)
       addition = cast_relation_class_for_extension(addition, key)
       if collection?
         extend_collection!(addition, key)
-      elsif _raw.is_a?(Array) || self[key]._raw.is_a?(Array)
+      elsif self[key]._raw.is_a? Array
         extend_array!(addition, key)
       elsif item?
         extend_item!(addition, key)
@@ -22,14 +22,14 @@ class LHS::Data
 
     private
 
-    def cast_relation_class_for_extension(addition, key = nil)
-      return addition if _record.nil? || key.nil? || _record._relations.nil? || _record._relations[key].nil?
+    def cast_relation_class_for_extension(addition, key)
+      return addition if _record.nil? || _record._relations.nil? || _record._relations[key].nil?
       addition.becomes(_record._relations[key][:record_class_name].constantize, errors: addition.errors, warnings: addition.warnings)
     end
 
-    def extend_collection!(addition, key = nil)
+    def extend_collection!(addition, key)
       map do |item|
-        item_raw = key ? item._raw[key] : item._raw
+        item_raw = item._raw[key]
         item_raw.blank? ? [nil] : item_raw
       end
         .flatten
@@ -45,25 +45,25 @@ class LHS::Data
         end
     end
 
-    def extend_array!(addition, key = nil)
-      (key ? self[key] : self).zip(addition) do |item, additional_item|
+    def extend_array!(addition, key)
+      self[key].zip(addition) do |item, additional_item|
         item._raw.merge!(additional_item._raw) if additional_item.present?
       end
     end
 
-    def extend_item!(addition, key = nil)
+    def extend_item!(addition, key)
       return if addition.nil?
       if addition.collection?
         extend_item_with_collection!(addition, key)
       else # simple case merges hash into hash
-        (key ? _raw[key.to_sym] : _raw).merge!(addition._raw)
+        _raw[key.to_sym].merge!(addition._raw)
       end
     end
 
-    def extend_item_with_collection!(addition, key = nil)
-      target = (key ? self[key] : self)
+    def extend_item_with_collection!(addition, key)
+      target = self[key]
       if target._raw.is_a? Array
-        self[key] = addition.map(&:_raw) if key
+        self[key] = addition.map(&:_raw)
       else # hash with items
         extend_item_with_hash_containing_items!(target, addition)
       end
@@ -72,11 +72,7 @@ class LHS::Data
     def extend_item_with_hash_containing_items!(target, addition)
       LHS::Collection.nest(input: target._raw, value: [], record: self) # inits the nested collection
       if LHS::Collection.access(input: target._raw, record: self).empty?
-        LHS::Collection.nest(
-          input: target._raw,
-          value: addition.reject { |item| item.nil? }.as_json,
-          record: self
-        )
+        LHS::Collection.nest(input: target._raw, value: addition.reject { |item| item.nil? }, record: self)
       else
         LHS::Collection.access(input: target._raw, record: self).each_with_index do |item, index|
           item.merge!(addition[index])

--- a/lib/lhs/concerns/data/extend.rb
+++ b/lib/lhs/concerns/data/extend.rb
@@ -13,7 +13,7 @@ class LHS::Data
       addition = cast_relation_class_for_extension(addition, key)
       if collection?
         extend_collection!(addition, key)
-      elsif self._raw.is_a?(Array) || self[key]._raw.is_a?(Array)
+      elsif _raw.is_a?(Array) || self[key]._raw.is_a?(Array)
         extend_array!(addition, key)
       elsif item?
         extend_item!(addition, key)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -178,12 +178,12 @@ class LHS::Record
       # Extends request options with options provided for this references
       def extend_with_references(options, references)
         return options if references.blank?
-        reference = references.except(:url)
+        references_without_url = references.except(:url)
         options ||= {}
         if options.is_a?(Array)
-          options.map { |request_options| request_options.merge(references) if request_options.present? }
+          options.map { |request_options| request_options.merge(references_without_url) if request_options.present? }
         elsif options.present?
-          options.merge(references)
+          options.merge(references_without_url)
         end
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -328,7 +328,25 @@ class LHS::Record
         )
 
         references.delete(:all) # for this reference all remote objects have been fetched
-        continue_including(sub_includes, addition, references)
+        continue_including(
+          sub_includes,
+          addition_after_merge(data, included, addition),
+          references
+        )
+      end
+
+      def addition_after_merge(data, included, addition)
+        if data.item?
+          data[included]
+        elsif data.collection?
+          LHS::Data.new(
+            data.map{|item| item[included] },
+            addition._parent,
+            addition._record,
+            addition._request,
+            addition._endpoint
+          )
+        end
       end
 
       def load_include_simple!(options, record)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -321,9 +321,20 @@ class LHS::Record
       end
 
       # Continues loading included resources after one complete batch/level has been fetched
-      def continue_including(data, including, referencing)
-        handle_includes(including, data, referencing) if including.present? && data.present?
+      def continue_including(data, included, reference)
+        return data if included.blank? || data.blank?
+        expand_data!(data, included, reference) unless expanded_data?(data)
+        handle_includes(included, data, reference)
         data
+      end
+
+      def expand_data!(data, included, reference)
+        options = options_for_data(data)
+        options = extend_with_reference(options, reference)
+        record = record_for_options(options) || self
+        options = convert_options_to_endpoints(options) if record_for_options(options)
+        expanded_data = record.request(options)
+        data.extend!(expanded_data)
       end
 
       # Loads all included/linked resources,

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -328,7 +328,7 @@ class LHS::Record
         data
       end
 
-      def expand_data!(data, included, reference)
+      def expand_data!(data, _included, reference)
         options = options_for_data(data)
         options = extend_with_reference(options, reference)
         record = record_for_options(options) || self

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -115,21 +115,30 @@ class LHS::Record
         data.clear_cache! if data.present? # as we just included new nested resources
       end
 
-      def handle_include(included, data, sub_includes = nil, reference = nil)
+      def handle_include(included, data, sub_includes = nil, references = nil)
         if data.blank? || skip_loading_includes?(data, included)
-          handle_skip_include(included, data, sub_includes, reference)
+          handle_skip_include(included, data, sub_includes, references)
         else
           options = options_for_data(data, included)
-          options = extend_with_reference(options, reference)
-          addition = load_existing_includes(options, data, sub_includes, reference)
-          data.extend!(addition, included)
-          expand_addition!(data, included, reference) unless expanded_data?(addition)
+          options = extend_with_references(options, references)
+          extend_and_expand_addition!(
+            addition: load_existing_includes(
+              included,
+              options,
+              data,
+              sub_includes,
+              references
+            ),
+            data: data,
+            included: included,
+            references: references
+          )
         end
       end
 
-      def handle_skip_include(included, data, sub_includes = nil, reference = nil)
+      def handle_skip_include(included, data, sub_includes = nil, references = nil)
         return if sub_includes.blank?
-        handle_includes(sub_includes, data[included], reference)
+        handle_includes(sub_includes, data[included], references)
       end
 
       def options_for_data(data, included = nil)
@@ -138,13 +147,15 @@ class LHS::Record
         url_option_for(data, included)
       end
 
-      def expand_addition!(data, included, reference)
-        addition = data[included]
-        options = options_for_data(addition)
-        options = extend_with_reference(options, reference)
+      def extend_and_expand_addition!(addition:, data:, included:, references:)
+        data.extend!(addition, included)
+        return if expanded_data?(addition)
+        options = options_for_data(data[included])
+        options = extend_with_references(options, references)
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         expanded_data = record.request(options)
+        addition.extend!(expanded_data)
         data.extend!(expanded_data, included)
       end
 
@@ -164,15 +175,15 @@ class LHS::Record
         end
       end
 
-      # Extends request options with options provided for this reference
-      def extend_with_reference(options, reference)
-        return options if reference.blank?
-        reference = reference.except(:url)
+      # Extends request options with options provided for this references
+      def extend_with_references(options, references)
+        return options if references.blank?
+        reference = references.except(:url)
         options ||= {}
         if options.is_a?(Array)
-          options.map { |request_options| request_options.merge(reference) if request_options.present? }
+          options.map { |request_options| request_options.merge(references) if request_options.present? }
         elsif options.present?
-          options.merge(reference)
+          options.merge(references)
         end
       end
 
@@ -280,10 +291,10 @@ class LHS::Record
         end
       end
 
-      def load_existing_includes(options, data, sub_includes, references)
+      def load_existing_includes(included, options, data, sub_includes, references)
         if data.collection? && data.any?(&:blank?)
           # filter only existing items
-          loaded_includes = load_include(options.compact, data.compact, sub_includes, references)
+          loaded_includes = load_include(included, options.compact, data.compact, sub_includes, references)
           # fill up skipped items before returning
           data.each_with_index do |item, index|
             next if item.present?
@@ -291,27 +302,34 @@ class LHS::Record
           end
           loaded_includes
         else
-          load_include(options, data, sub_includes, references)
+          load_include(included, options, data, sub_includes, references)
         end
       end
 
       # Load additional resources that are requested with include
-      def load_include(options, _data, sub_includes, references)
+      def load_include(included, options, data, sub_includes, references)
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         prepare_options_for_include_request!(options, sub_includes, references)
         if references && references[:all] # include all linked resources
-          load_include_all!(options, record, sub_includes, references)
+          load_include_all!(included, options, data, record, sub_includes, references)
         else # simply request first page/batch
           load_include_simple!(options, record)
         end
       end
 
-      def load_include_all!(options, record, sub_includes, references)
+      def load_include_all!(included, options, data, record, sub_includes, references)
         prepare_options_for_include_all_request!(options)
-        data = load_all_included!(record, options)
+        addition = load_all_included!(record, options)
+        extend_and_expand_addition!(
+          addition: addition,
+          data: data,
+          included: included,
+          references: references
+        )
+
         references.delete(:all) # for this reference all remote objects have been fetched
-        continue_including(data, sub_includes, references)
+        continue_including(sub_includes, addition, references)
       end
 
       def load_include_simple!(options, record)
@@ -321,8 +339,9 @@ class LHS::Record
       end
 
       # Continues loading included resources after one complete batch/level has been fetched
-      def continue_including(data, including, referencing)
-        handle_includes(including, data, referencing) if including.present? && data.present?
+      def continue_including(includes, data, references)
+        return data if includes.blank? || data.blank?
+        handle_includes(includes, data, references)
         data
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -321,7 +321,7 @@ class LHS::Record
       def load_include_all!(included, options, data, record, sub_includes, references)
         prepare_options_for_include_all_request!(options)
         addition = load_all_included!(record, options)
-        expanded_addition = extend_and_expand_addition!(
+        expanded_data = extend_and_expand_addition!(
           addition: addition,
           data: data,
           included: included,
@@ -329,7 +329,25 @@ class LHS::Record
         )
 
         references.delete(:all) # for this reference all remote objects have been fetched
-        continue_including(sub_includes, expanded_addition, references)
+        continue_including(
+          sub_includes,
+          addition_after_expansion(data, included, addition),
+          references
+        )
+      end
+
+      def addition_after_expansion(data, included, addition)
+        if data.item?
+          data[included]
+        elsif data.collection?
+          LHS::Data.new(
+            data.map{|item| item[included] },
+            addition._parent,
+            addition._record,
+            addition._request,
+            addition._endpoint
+          )
+        end
       end
 
       def load_include_simple!(options, record)

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -155,7 +155,6 @@ class LHS::Record
         record = record_for_options(options) || self
         options = convert_options_to_endpoints(options) if record_for_options(options)
         expanded_data = record.request(options)
-        addition.extend!(expanded_data)
         data.extend!(expanded_data, included)
       end
 

--- a/lib/lhs/concerns/record/request.rb
+++ b/lib/lhs/concerns/record/request.rb
@@ -156,6 +156,7 @@ class LHS::Record
         options = convert_options_to_endpoints(options) if record_for_options(options)
         expanded_data = record.request(options)
         data.extend!(expanded_data, included)
+        expanded_data
       end
 
       def expanded_data?(addition)
@@ -320,7 +321,7 @@ class LHS::Record
       def load_include_all!(included, options, data, record, sub_includes, references)
         prepare_options_for_include_all_request!(options)
         addition = load_all_included!(record, options)
-        extend_and_expand_addition!(
+        expanded_addition = extend_and_expand_addition!(
           addition: addition,
           data: data,
           included: included,
@@ -328,25 +329,7 @@ class LHS::Record
         )
 
         references.delete(:all) # for this reference all remote objects have been fetched
-        continue_including(
-          sub_includes,
-          addition_after_merge(data, included, addition),
-          references
-        )
-      end
-
-      def addition_after_merge(data, included, addition)
-        if data.item?
-          data[included]
-        elsif data.collection?
-          LHS::Data.new(
-            data.map{|item| item[included] },
-            addition._parent,
-            addition._record,
-            addition._request,
-            addition._endpoint
-          )
-        end
+        continue_including(sub_includes, expanded_addition, references)
       end
 
       def load_include_simple!(options, record)

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '25.0.3'
+  VERSION = '25.0.4'
 end

--- a/spec/record/compact_spec.rb
+++ b/spec/record/compact_spec.rb
@@ -66,6 +66,11 @@ describe LHS::Record do
   end
 
   context '.compact' do
+    
+    it 'does NOT return an internal data type, but the Record class' do
+      expect(places.compact.class).to eq User
+    end
+
     it 'removes linked resouces which could not get fetched' do
       expect(places.compact.length).to eq 1
       expect(places.length).not_to eq 1 # leaves the original intact

--- a/spec/record/compact_spec.rb
+++ b/spec/record/compact_spec.rb
@@ -66,7 +66,7 @@ describe LHS::Record do
   end
 
   context '.compact' do
-    
+
     it 'does NOT return an internal data type, but the Record class' do
       expect(places.compact.class).to eq User
     end

--- a/spec/record/includes_after_expansion_spec.rb
+++ b/spec/record/includes_after_expansion_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe LHS::Record do
   context 'includes records after expansion' do
-    
+
     before do
       class User < LHS::Record
         endpoint 'http://users/{id}'

--- a/spec/record/includes_after_expansion_spec.rb
+++ b/spec/record/includes_after_expansion_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe LHS::Record do
+  context 'includes records after expansion' do
+    
+    before do
+      class User < LHS::Record
+        endpoint 'http://users/{id}'
+      end
+
+      class Places < LHS::Record
+        endpoint 'http://users/{id}/places'
+        endpoint 'http://places/{id}'
+      end
+
+      class Contracts < LHS::Record
+        endpoint 'http://places/{place_id}/contracts'
+      end
+
+      stub_request(:get, 'http://users/1')
+        .to_return(
+          body: {
+            places: {
+              href: 'http://users/1/places'
+            }
+          }.to_json
+        )
+
+      stub_request(:get, 'http://users/1/places?limit=100')
+        .to_return(
+          body: {
+            items: [
+              { href: 'http://places/345' }
+            ],
+            total: 1,
+            offset: 0,
+            limit: 10
+          }.to_json
+        )
+
+      stub_request(:get, 'http://places/345')
+        .to_return(
+          body: {
+            contracts: {
+              href: "http://places/345/contracts?offset=0&limit=10"
+            }
+          }.to_json
+        )
+
+      stub_request(:get, 'http://places/345/contracts?offset=0&limit=10')
+        .to_return(
+          body: {
+            items: [
+              {
+                product: { name: 'OPL' }
+              }
+            ]
+          }.to_json
+        )
+
+    end
+
+    it 'includes resources after expanding plain links' do
+      user = User.includes(places: :contracts).find(1)
+      expect(
+        user.places.first.contracts.first.product.name
+      ).to eq 'OPL'
+    end
+  end
+end

--- a/spec/record/request_spec.rb
+++ b/spec/record/request_spec.rb
@@ -54,12 +54,12 @@ describe LHS::Record do
 
   context '#extend_with_reference' do
     it 'extends given options with the one for the refernce' do
-      options = LHS::Record.send(:extend_with_reference, { url: 'http://datastore/feedbacks/1' }, { auth: { bearer: '123' } })
+      options = LHS::Record.send(:extend_with_references, { url: 'http://datastore/feedbacks/1' }, { auth: { bearer: '123' } })
       expect(options[:auth][:bearer]).to eq '123'
     end
 
     it 'extends given list of options with the one for the refernce' do
-      options = LHS::Record.send(:extend_with_reference, [{ url: 'http://datastore/feedbacks/1' }], auth: { bearer: '123' })
+      options = LHS::Record.send(:extend_with_references, [{ url: 'http://datastore/feedbacks/1' }], auth: { bearer: '123' })
       expect(options[0][:auth][:bearer]).to eq '123'
     end
   end

--- a/spec/record/request_spec.rb
+++ b/spec/record/request_spec.rb
@@ -54,12 +54,12 @@ describe LHS::Record do
 
   context '#extend_with_reference' do
     it 'extends given options with the one for the refernce' do
-      options = LHS::Record.send(:extend_with_references, { url: 'http://datastore/feedbacks/1' }, { auth: { bearer: '123' } })
+      options = LHS::Record.send(:extend_with_reference, { url: 'http://datastore/feedbacks/1' }, { auth: { bearer: '123' } })
       expect(options[:auth][:bearer]).to eq '123'
     end
 
     it 'extends given list of options with the one for the refernce' do
-      options = LHS::Record.send(:extend_with_references, [{ url: 'http://datastore/feedbacks/1' }], auth: { bearer: '123' })
+      options = LHS::Record.send(:extend_with_reference, [{ url: 'http://datastore/feedbacks/1' }], auth: { bearer: '123' })
       expect(options[0][:auth][:bearer]).to eq '123'
     end
   end


### PR DESCRIPTION
When performing includes via multiple levels, .e.g.

```ruby
User.includes(places: :contracts)
```

LHS had problems to continue including nested includes, when there were unexpanded links in between, like places in this example, as `users/id/places` returns just a list of unexpanded place links.

This PR makes sure that LHS expands loaded links before continuing with includes.