### PR TITLE
Do not follow Location header when followlocation option is set to false

### DIFF
--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -45,7 +45,7 @@ class LHS::Item < LHS::Proxy
         _data.merge_raw!(response_data.unwrap(:item_created_key))
         response_headers = response_data._request.response.headers
       end
-      if response_headers && response_headers['Location']
+      if options.fetch(:followlocation, true) && response_headers && response_headers['Location']
         location_data = record.request(options.merge(url: response_headers['Location'], method: :get, body: nil))
         _data.merge_raw!(location_data.unwrap(:item_created_key))
       end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '25.0.4'
+  VERSION = '25.1.0'
 end

--- a/spec/record/create_spec.rb
+++ b/spec/record/create_spec.rb
@@ -135,25 +135,61 @@ describe LHS::Record do
     end
 
     context 'location header' do
-      before do
-        class ContactPerson < LHS::Record
-          endpoint 'http://datastore/contact_persons'
+      let(:created_at) { '2017-12-21' }
+      let(:location)   { 'http://datastore/contact_persons/1' }
+      let(:name)       { 'Sebastian' }
+
+      context 'without `followlocation` option' do
+        before do
+          class ContactPerson < LHS::Record
+            endpoint 'http://datastore/contact_persons'
+          end
+        end
+
+        it 'loads the data from the "Location" header after creation' do
+          stub_request(:post, "http://datastore/contact_persons")
+            .to_return(status: 204, headers: { Location: location })
+          stub_request(:get, "http://datastore/contact_persons/1")
+            .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
+          contact_person = ContactPerson.create!(name: name)
+          expect(contact_person.href).to eq location
+          expect(contact_person.created_at).to eq Date.parse(created_at)
+          expect(contact_person.name).to eq name
         end
       end
 
-      let(:location)   { 'http://datastore/contact_persons/1' }
-      let(:created_at) { '2017-12-21' }
-      let(:name)       { 'Sebastian' }
+      context 'when `followlocation` is set to `true`' do
+        before do
+          class ContactPerson < LHS::Record
+            endpoint 'http://datastore/contact_persons', followlocation: true
+          end
+        end
 
-      it 'Loads the data from the "Location" header after creation' do
-        stub_request(:post, "http://datastore/contact_persons")
-          .to_return(status: 204, headers: { Location: location })
-        stub_request(:get, "http://datastore/contact_persons/1")
-          .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
-        contact_person = ContactPerson.create!(name: name)
-        expect(contact_person.href).to eq location
-        expect(contact_person.created_at).to eq Date.parse(created_at)
-        expect(contact_person.name).to eq name
+        it 'loads the data from the "Location" header after creation' do
+          stub_request(:post, "http://datastore/contact_persons")
+            .to_return(status: 204, headers: { Location: location })
+          stub_request(:get, "http://datastore/contact_persons/1")
+            .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
+          contact_person = ContactPerson.create!(name: name)
+          expect(contact_person.href).to eq location
+          expect(contact_person.created_at).to eq Date.parse(created_at)
+          expect(contact_person.name).to eq name
+        end
+      end
+
+      context 'when `followlocation` is set to `false`' do
+        before do
+          class ContactPerson < LHS::Record
+            endpoint 'http://datastore/contact_persons', followlocation: false
+          end
+        end
+
+        it 'does not load the data from the "Location" header after creation' do
+          stub_request(:post, "http://datastore/contact_persons")
+            .to_return(status: 204, headers: { Location: location })
+          contact_person = ContactPerson.create!(name: name)
+          expect(contact_person.name).to eq name
+        end
       end
     end
   end

--- a/spec/record/create_spec.rb
+++ b/spec/record/create_spec.rb
@@ -138,6 +138,14 @@ describe LHS::Record do
       let(:created_at) { '2017-12-21' }
       let(:location)   { 'http://datastore/contact_persons/1' }
       let(:name)       { 'Sebastian' }
+      let!(:create_contact_person_request) do
+        stub_request(:post, "http://datastore/contact_persons")
+          .to_return(status: 204, headers: { Location: location })
+      end
+      let!(:fetch_contact_person_request) do
+        stub_request(:get, "http://datastore/contact_persons/1")
+          .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
+      end
 
       context 'without `followlocation` option' do
         before do
@@ -147,11 +155,9 @@ describe LHS::Record do
         end
 
         it 'loads the data from the "Location" header after creation' do
-          stub_request(:post, "http://datastore/contact_persons")
-            .to_return(status: 204, headers: { Location: location })
-          stub_request(:get, "http://datastore/contact_persons/1")
-            .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
           contact_person = ContactPerson.create!(name: name)
+          expect(create_contact_person_request).to have_been_made.once
+          expect(fetch_contact_person_request).to have_been_made.once
           expect(contact_person.href).to eq location
           expect(contact_person.created_at).to eq Date.parse(created_at)
           expect(contact_person.name).to eq name
@@ -166,11 +172,9 @@ describe LHS::Record do
         end
 
         it 'loads the data from the "Location" header after creation' do
-          stub_request(:post, "http://datastore/contact_persons")
-            .to_return(status: 204, headers: { Location: location })
-          stub_request(:get, "http://datastore/contact_persons/1")
-            .to_return(body: { href: location, name: name, created_at: created_at }.to_json)
           contact_person = ContactPerson.create!(name: name)
+          expect(create_contact_person_request).to have_been_made.once
+          expect(fetch_contact_person_request).to have_been_made.once
           expect(contact_person.href).to eq location
           expect(contact_person.created_at).to eq Date.parse(created_at)
           expect(contact_person.name).to eq name
@@ -185,9 +189,9 @@ describe LHS::Record do
         end
 
         it 'does not load the data from the "Location" header after creation' do
-          stub_request(:post, "http://datastore/contact_persons")
-            .to_return(status: 204, headers: { Location: location })
           contact_person = ContactPerson.create!(name: name)
+          expect(create_contact_person_request).to have_been_made.once
+          expect(fetch_contact_person_request).not_to have_been_made
           expect(contact_person.name).to eq name
         end
       end


### PR DESCRIPTION
# Description
We already use `followlocation` option in `lhc` when we want to follow the redirects: https://github.com/local-ch/lhc/blob/master/README.md#follow-redirects
This PR adds the changes that `lhs` takes into account this option when it's going to follow the `Location` header in the response.
Only minor release since the default behaviour hasn't changed.