### PR TITLE
Fix auth options precedence for auto auth

### DIFF
--- a/lib/lhs/interceptors/auto_oauth/interceptor.rb
+++ b/lib/lhs/interceptors/auto_oauth/interceptor.rb
@@ -10,7 +10,7 @@ module LHS
       class Interceptor < LHC::Interceptor
 
         def before_request
-          request.options[:auth] = { bearer: token }
+          request.options[:auth] ||= { bearer: token }
         end
 
         def tokens

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '26.0.0'
+  VERSION = '26.0.1'
 end

--- a/spec/auto_oauth_spec.rb
+++ b/spec/auto_oauth_spec.rb
@@ -165,5 +165,46 @@ describe 'Auto OAuth Authentication', type: :request, dummy_models: true do
         expect(records_request).to have_been_requested
       end
     end
+
+    context 'overriding auth options with provider enabled for auto oauth' do
+
+      let(:token) { ApplicationController::ACCESS_TOKEN }
+      let(:overridden_token) { 'ACCESS_TOKEN' }
+
+      let(:record_request) do
+        stub_request(:get, "http://internalservice/v2/records/1")
+          .with(
+            headers: { 'Authorization' => "Bearer #{overridden_token}" }
+          ).to_return(status: 200, body: { name: 'Record' }.to_json)
+      end
+
+      let(:records_request) do
+        stub_request(:get, "http://internalservice/v2/records?color=blue")
+          .with(
+            headers: { 'Authorization' => "Bearer #{overridden_token}" }
+          ).to_return(status: 200, body: { items: [{ name: 'Record' }] }.to_json)
+      end
+
+      before do
+        LHS.configure do |config|
+          config.auto_oauth = -> { access_token }
+        end
+        LHC.configure do |config|
+          config.interceptors = [LHC::Auth]
+        end
+        record_request
+        records_request
+      end
+
+      after do
+        LHC.config.reset
+      end
+
+      it 'applies OAuth credentials for the individual request automatically' do
+        get '/automatic_authentication/oauth_with_provider_override', params: { access_token: overridden_token }
+        expect(record_request).to have_been_requested
+        expect(records_request).to have_been_requested
+      end
+    end
   end
 end

--- a/spec/dummy/app/controllers/automatic_authentication_controller.rb
+++ b/spec/dummy/app/controllers/automatic_authentication_controller.rb
@@ -26,4 +26,11 @@ class AutomaticAuthenticationController < ApplicationController
       records: DummyRecordWithAutoOauthProvider.where(color: 'blue').as_json
     }
   end
+
+  def o_auth_with_provider_override
+    render json: {
+      record: DummyRecordWithAutoOauthProvider.options(auth: { bearer: params[:access_token] }).find(1).as_json,
+      records: DummyRecordWithAutoOauthProvider.options(auth: { bearer: params[:access_token] }).where(color: 'blue').as_json
+    }
+  end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get 'automatic_authentication/oauth' => 'automatic_authentication#o_auth'
   get 'automatic_authentication/oauth_with_multiple_providers' => 'automatic_authentication#o_auth_with_multiple_providers'
   get 'automatic_authentication/oauth_with_provider' => 'automatic_authentication#o_auth_with_provider'
+  get 'automatic_authentication/oauth_with_provider_override' => 'automatic_authentication#o_auth_with_provider_override'
 
   # Request Cycle Cache
   get 'request_cycle_cache/simple' => 'request_cycle_cache#simple'


### PR DESCRIPTION
_PATCH_

Allows to use auth options which takes precedence over auto auth.
https://github.com/local-ch/lhs#automatic-authentication-oauth

```ruby
Record.options(auth: {. bearer: 'ACCESS_TOKEN'}).find(12345)
```