### PR TITLE
Add possibility to override HTTP request's method when chaining save with options.

### DIFF
--- a/lhs.gemspec
+++ b/lhs.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'json', '>=  1.8.2'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'
-  s.add_development_dependency 'rails', '>= 4.2.11'
+  s.add_development_dependency 'rails', '>= 4.2.11', '< 7'
   s.add_development_dependency 'rollbar', '<= 2.24.0'
   s.add_development_dependency 'rspec-rails', '>= 3.7.0'
   s.add_development_dependency 'rubocop', '~> 0.57.1'

--- a/lib/lhs/concerns/item/save.rb
+++ b/lib/lhs/concerns/item/save.rb
@@ -34,7 +34,7 @@ class LHS::Item < LHS::Proxy
     private
 
     def apply_default_creation_options(options, url, data)
-      options = options.merge(method: :post, url: url, body: data)
+      options = options.merge(method: options.fetch(:method, :post), url: url, body: data)
       options[:headers] ||= {}
       options
     end

--- a/lib/lhs/version.rb
+++ b/lib/lhs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LHS
-  VERSION = '26.0.1'
+  VERSION = '26.1.0'
 end

--- a/spec/item/save_spec.rb
+++ b/spec/item/save_spec.rb
@@ -112,4 +112,14 @@ describe LHS::Item do
       expect(request).to have_been_requested
     end
   end
+
+  context 'chainable' do
+    it 'allows to chain save with options' do
+      stub_request(:put, item.href).with(body: item._raw.merge(name: 'Steve').to_json)
+      item.name = 'Steve'
+      result = item.options(method: :put).save
+
+      expect(result).to eq true
+    end
+  end
 end


### PR DESCRIPTION
# Context
The method `save` might be used to update existing entity, in such case, sometimes, another HTTP verb is needed.
This PR adds possibility to override default `POST` method by chaining `save` with `options` like:
`Entity.options(method: :put).save`