### PR TITLE
Add Dependabot Configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Set update schedule for GitHub Actions
+# From: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+
+# Enable dependency graph:
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month, valid values:
+      # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval
+      interval: "monthly"


### PR DESCRIPTION
This PR adds [Dependabot for GitHub Actions](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot). Dependabot will automatically create PRs to keep the GitHub Actions dependencies up-to-date.

After merging this PR, a repository admin/owner needs to enable Dependabot for GitHub Actions in the repository settings.

- [x] Got to Repository Settings  >> Code Security >> Enable Dependabot on Actions runners
  - [x] Please do not enable Dependabot on self-hosted runners. It is not supported yet.

> :bulb: Please consider adding Dependabot for your project's language itself, not just the GitHub Actions. **Dependabot supports various other package ecosystems like NodeJS, Java, Python, etc.** You can add configuration sections for them as well in `.github/dependabot.yml` file. For more information, check the [Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file).

> :dart: Please merge or close this PR yourself,  thank you!
